### PR TITLE
Auto directory index pages and JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Your site is now running at `http://localhost:8000`!
 
 # TODO
 * Add sitewide nav menu
+* Add automatic directory index pages for each directory
+  * Change index.md template to use its own template
 * Add redirects
-* Add [gatsby-plugin-json-output](https://www.gatsbyjs.org/packages/gatsby-plugin-json-output/) for JSON files and feeds
 * Use frontmatter to set `<meta>` and other related tags (swiftype, SEO, hreflang links)
 * Add field validation for certain graphql/frontmatter types
   * `path`: ensure unique. decide if user should supply or automatically generated based on directory? use default gatsby pattern (slugified directory and filename path) if not specified

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -37,6 +37,33 @@ module.exports = {
     },
     `gatsby-transformer-remark`,
     {
+      resolve: `gatsby-plugin-json-output`,
+      options: {
+        siteUrl: 'http://localhost.com:8000',
+        graphQLQuery: `
+        {
+          allMarkdownRemark {
+            edges {
+              node {
+                html
+                fields { urlPath }
+                frontmatter {
+                  title
+                  path
+                }
+              }
+            }
+          }
+        }
+      `,
+      serialize: results => results.data.allMarkdownRemark.edges.map(({ node }) => ({
+        path: node.fields.urlPath, // MUST contain a path
+        title: node.frontmatter.title,
+        html: node.html,
+      })),
+      }
+    },
+    {
       resolve: 'gatsby-plugin-netlify-cms',
     },
   ],

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -61,6 +61,12 @@ module.exports = {
         title: node.frontmatter.title,
         html: node.html,
       })),
+      serializeFeed: results => results.data.allMarkdownRemark.edges.map(({ node }) => ({
+        id: node.fields.urlPath,
+        url: 'http://localhost:8000' + node.fields.urlPath,
+        title: node.frontmatter.title,
+      })),
+      nodesPerFeedFile: 100,
       }
     },
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -45,11 +45,13 @@ module.exports = {
           allMarkdownRemark {
             edges {
               node {
-                html
-                fields { urlPath }
                 frontmatter {
                   title
                   path
+                }
+                html
+                fields {
+                  urlPath
                 }
               }
             }
@@ -63,10 +65,56 @@ module.exports = {
       })),
       serializeFeed: results => results.data.allMarkdownRemark.edges.map(({ node }) => ({
         id: node.fields.urlPath,
-        url: 'http://localhost:8000' + node.fields.urlPath,
+        url: `http://localhost:8000${node.fields.urlPath}/index.json`,
         title: node.frontmatter.title,
       })),
       nodesPerFeedFile: 100,
+      feedName: 'allContent'
+      }
+    },
+    {
+      resolve: `gatsby-plugin-json-output`,
+      options: {
+        siteUrl: 'http://localhost.com:8000',
+        graphQLQuery: `
+        {
+          allMarkdownRemark(filter: {frontmatter: {contentType: {eq: "attributeDefinition"}}}) {
+            edges {
+              node {
+                frontmatter {
+                  title
+                  path
+                  dataSources
+                  dataTypes
+                  shortDescription
+                  unitOfMeasure
+                }
+                html
+                fields {
+                  urlPath
+                }
+              }
+            }
+          }
+        }
+      `,
+      serialize: results => results.data.allMarkdownRemark.edges.map(({ node }) => ({
+        path: node.fields.urlPath, // MUST contain a path
+        title: node.frontmatter.title,
+        html: node.html,
+      })),
+      serializeFeed: results => results.data.allMarkdownRemark.edges.map(({ node }) => ({
+        id: node.fields.urlPath,
+        url: `http://localhost:8000${node.fields.urlPath}/index.json`,
+        title: node.frontmatter.title,
+        dataSources: node.frontmatter.dataSources,
+        dataTypes: node.frontmatter.dataTypes,
+        shortDescription: node.frontmatter.shortDescription,
+        unitOfMeasure: node.frontmatter.unitOfMeasure,
+        html: node.html
+      })),
+      nodesPerFeedFile: 100,
+      feedName: 'attributeDefinitions'
       }
     },
     {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,8 +1,24 @@
 const path = require(`path`);
 const { createFilePath } = require(`gatsby-source-filesystem`)
+const AUTOBUILD_INDEXES = true;
+
+exports.onCreateNode = ({ node, getNode, actions }) => {
+  const { createNodeField } = actions
+  if (node.internal.type === 'MarkdownRemark') {
+    let slug = node.frontmatter.path || createFilePath({ node, getNode, trailingSlash: false })
+    createNodeField({
+      node,
+      name: 'urlPath',
+      value: slug,
+    })
+  }
+}
 
 exports.createPages = async ({ actions, graphql, reporter }) => {
   const { createPage } = actions;
+  let subdirsWithIndexPages = [];
+  let subdirIndexesToCreate = [];
+  let subdirIndexPages = {};
   const result = await graphql(`
   {
     allMarkdownRemark {
@@ -20,7 +36,20 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
               relativePath
             }
           }
+          fileAbsolutePath
+          fields {
+            urlPath
+          }
         }
+      }
+    }
+    allDirectory {
+      nodes {
+        absolutePath
+        base
+        relativePath
+        name
+        relativeDirectory
       }
     }
   }
@@ -32,26 +61,80 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     return;
   }
 
+  function recordAsChild(subdir, child, isDir){
+    subdirIndexPages[subdir] = typeof(subdirIndexPages[subdir])==='object' ? subdirIndexPages[subdir] : {children:{
+      dirs: [],
+      md: []
+    }}
+    const target = isDir ? subdirIndexPages[subdir].children.dirs : subdirIndexPages[subdir].children.md;
+    target.push(child);
+  }
+
   result.data.allMarkdownRemark.edges.forEach(({ node }) => {
     const relativePath = node.parent.relativePath.split('.')
+    // Get dir of file
+    const subdirAbs = path.dirname(node.fileAbsolutePath);
+    // Note that this md file is child of dir
+    recordAsChild(subdirAbs,node,false);
     createPage({
       path: node.frontmatter.path || `/${relativePath[0]}`,
       component: path.resolve(
         `src/templates/${node.frontmatter.templateKey}.js`
       ),
-      context: {}, // additional data can be passed via context
+      context: {
+        urlPath: node.frontmatter.path || `/${relativePath[0]}`
+      }, // additional data can be passed via context
     });
   });
+  // Iterate over directories that contain MD, and check if they need an index page created
+  let directoryIteratorPromise = new Promise((resolve,reject) =>{
+    result.data.allDirectory.nodes.forEach(async (node, index, arr)=>{
+      const subdirAbs = node.absolutePath;
+      const subdirRel = node.relativePath;
+      const parentDir = path.posix.dirname(subdirAbs);
+      // Note child of dir
+      recordAsChild(parentDir,node,true);
+      // Create page for subdir that file is in, if it is missing an index page. Skip for homepage ('/'), or top level page (/test.md)
+      const alreadyHasIndexPage = (subdirsWithIndexPages.indexOf(subdirAbs)!==-1 || subdirRel === '');
+      if (!alreadyHasIndexPage){
+        // Check for index.md
+        const indexPath = path.posix.join(subdirAbs,'index.md');
+        const existResult = await graphql(`
+        {
+          allMarkdownRemark(filter: {fileAbsolutePath: {eq: "${indexPath}"}}) {
+            totalCount
+          }
+        }`);
+        if (existResult.data.allMarkdownRemark.totalCount < 1) {
+          console.log(`There is no index for ${indexPath}`);
+          subdirIndexesToCreate.push({
+            subdirAbs: subdirAbs,
+            subdirRel: subdirRel,
+            parentDir: parentDir
+          });
+        }
+        subdirsWithIndexPages.push(subdirAbs);
+      }
+      if (index === arr.length-1) resolve();
+    });
+  });
+  if (AUTOBUILD_INDEXES) {
+    directoryIteratorPromise.then(()=>{
+      console.log('=============== BUILDING SUBDIR INDEX PAGES! ======================');
+      for (let x=0; x<subdirIndexesToCreate.length; x++){
+        const subdirPaths = subdirIndexesToCreate[x];
+        // Create index page!
+        actions.createPage({
+          path: subdirPaths.subdirRel,
+          component: path.resolve(`./src/templates/directory-index.js`),
+          context: {
+            slug: subdirPaths.subdirRel,
+            hasIndex: false,
+            meta: subdirIndexPages[subdirPaths.subdirAbs]
+          }
+        });
+      }
+    });
+  }
 };
 
-exports.onCreateNode = ({ node, getNode, actions }) => {
-  const { createNodeField } = actions
-  if (node.internal.type === 'MarkdownRemark') {
-    let slug = node.frontmatter.path || createFilePath({ node, getNode, trailingSlash: false })
-    createNodeField({
-      node,
-      name: 'urlPath',
-      value: slug,
-    })
-  }
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "developer-website",
+  "name": "nr-docs-ssg-prototype",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -4895,8 +4895,7 @@
     "colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "optional": true
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -8500,25 +8499,25 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "optional": true,
           "requires": {
@@ -8528,13 +8527,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "optional": true,
           "requires": {
@@ -8550,25 +8549,25 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
@@ -8583,19 +8582,19 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
@@ -8610,13 +8609,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
@@ -8646,13 +8645,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "optional": true,
           "requires": {
@@ -8670,7 +8669,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
@@ -8686,13 +8685,13 @@
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "optional": true,
           "requires": {
@@ -8701,13 +8700,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "optional": true,
           "requires": {
@@ -8821,7 +8820,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
@@ -8833,19 +8832,19 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "optional": true,
           "requires": {
@@ -8854,19 +8853,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
@@ -8876,7 +8875,7 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
@@ -8888,7 +8887,7 @@
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "optional": true,
           "requires": {
@@ -8924,19 +8923,19 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
@@ -8948,19 +8947,19 @@
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "optional": true,
           "requires": {
@@ -8971,7 +8970,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
@@ -8980,7 +8979,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "optional": true,
           "requires": {
@@ -8989,7 +8988,7 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
@@ -9010,13 +9009,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "optional": true,
           "requires": {
@@ -9025,7 +9024,7 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "optional": true
         },
@@ -9474,6 +9473,14 @@
         "glob": "^7.1.6",
         "lodash": "^4.17.15",
         "micromatch": "^3.1.10"
+      }
+    },
+    "gatsby-plugin-json-output": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-json-output/-/gatsby-plugin-json-output-1.1.3.tgz",
+      "integrity": "sha512-tTW2O1zipTLrZNPXZhH9oNh9nq5GPheznqcBzvrcGUZjS+6KlDnzDwrjI2k/t+7HsEfYDZh0cye3UiGZ7Ow28w==",
+      "requires": {
+        "colors": "^1.4.0"
       }
     },
     "gatsby-plugin-manifest": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "classnames": "^2.2.6",
     "gatsby": "^2.20.25",
     "gatsby-image": "^2.3.4",
+    "gatsby-plugin-json-output": "^1.1.3",
     "gatsby-plugin-manifest": "^2.3.5",
     "gatsby-plugin-netlify-cms": "^4.3.0",
     "gatsby-plugin-offline": "^3.1.4",

--- a/src/content/docs/agents/node-agent/configuration/node-agent-config.md
+++ b/src/content/docs/agents/node-agent/configuration/node-agent-config.md
@@ -1,0 +1,2159 @@
+---
+title: Node agent configuration
+path: /agents/node-js/config/node-agent-configuration
+contentType: basicDoc
+templateKey: BasicDocPageTemplate
+topics:
+  - Agents
+  - Node.js
+  - Configuration
+moreInfoLinks:
+- link: "/docs/agents/php-agent/troubleshooting/no-data-appears-php"
+  text: "No data appears (PHP)"
+metaDescription: "For configuration of New Relic's node.js agent for linux read this."
+---
+<p>You can tailor New Relic's Node.js agent to your app's requirements by editing your <code>newrelic.js</code> config file or by setting an environment variable. The config file resides in the root directory of your app. You can also configure a few options from the New Relic UI, or use New Relic's <a href="/docs/agents/nodejs-agent/api-guides/nodejs-agent-api">Node.js agent API</a>.</p>
+
+<div class="callout-important">
+<p>The <a href="#license"><code>license_key</code></a> setting is required. New Relic <b>highly recommends</b> setting the <a href="#app_name"><code>app_name</code></a> so that your app has a <a href="/docs/apm/new-relic-apm/installation-configuration/name-your-application">meaningful name</a> instead of the default <code>My Application</code>.</p>
+</div>
+
+<h2 id="methods-and-precedence">Configuration methods and precedence</h2>
+
+<p id="hierarchy">The primary method to configure the Node.js agent is the agent configuration file (<code>newrelic.js</code>). You can also configure most settings with <a href="#environment">environment variables</a>. You can also adjust some settings with <a href="#server-side">server-side configuration</a>.</p>
+
+<p>The Node.js agent uses this order of precedence for configuration methods:</p>
+
+<div class="dnd-atom-wrapper type-image context-inline_image" contenteditable="false">
+<div class="dnd-drop-wrapper"><!-- scald=7641:inline_image {"link":""} --><img alt="Node.js agent configuration precedence" height="358" src="https://docs-dev.newrelic.com/sites/default/files/styles/inline_660px/public/thumbnails/image/nodejs-configuration-precedence.png?itok=T2PLMciG" title="Node.js agent configuration precedence" typeof="foaf:Image" width="583" /><!-- END scald=7641 --></div>
+
+<div class="dnd-legend-wrapper" contenteditable="true">
+<div class="meta"><b>Node.js configuration hierarchy:</b> Server-side configuration settings override environment variables. Environment variables override the agent config file. The config file overrides the agent defaults.</div>
+</div>
+</div>
+
+<p>Here are detailed descriptions of each configuration method:</p>
+
+<dl class="clamshell-list">
+	<dt class="freq-link" id="config_file">Agent configuration file</dt>
+	<dd>
+	<p>The config file (<code>newrelic.js</code>) contains every Node.js agent setting. When you <a href="/docs/agents/nodejs-agent/installation-configuration/installing-maintaining-nodejs#installing">install the Node.js agent</a>, you must copy <code>newrelic.js</code> into your app's root directory. Most settings are empty by default; they inherit their values from <code>config/default.js</code>.</p>
+	</dd>
+	<dt class="freq-link" id="environment">Environment variables</dt>
+	<dd>
+	<p>Most configuration settings in <code>newrelic.js</code> have equivalent environment variables. These are useful, for example, if your agent runs in a PaaS enviornment such as Heroku or Microsoft Azure. Node.js agent environment variables always start with <code>NEW_RELIC_</code>.</p>
+
+	<p>Where available, these environment variables are documented below under individual config options as the <b>Environ variable</b>. There are also two rarely used settings that can <a href="#environment-variable-overrides">only be configured via environment variables</a>.</p>
+	</dd>
+	<dt class="freq-link" id="server-side">Server-side configuration</dt>
+	<dd>
+	<div class="callout-permissions">
+	<p><b>Owner or Admins</b></p>
+	</div>
+
+	<p id="ui_settings">Owners and Admins can view and configure a few settings <a href="/docs/agents/manage-apm-agents/configuration/server-side-agent-configuration">directly in the New Relic UI</a>. Where available, the UI labels for server-side config are listed in this document under individual config options as the <b>Server-side label</b>.</p>
+	</dd>
+</dl>
+
+<h2 id="exports_config">Exports variables</h2>
+
+<p>This section defines the Node.js agent variables in the order they typically appear in the <code>exports.config = {</code> section of your app's <code>newrelic.js</code> configuration file.</p>
+
+<dl class="clamshell-list">
+	<dt id="app_name">app_name <span style="color: red">(HIGHLY RECOMMENDED)</span></dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>String</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>"My Application"</td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_APP_NAME</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>The <a href="/docs/apm/new-relic-apm/installation-configuration/name-your-application">name New Relic uses to identify your app</a>. For example, <code>app_name: ['<var>MyNodeApp</var>']</code>. To <a href="/docs/apm/new-relic-apm/installation-configuration/use-multiple-names-app">use multiple names for your app</a>, specify a comma-delimited list of names.</p>
+
+	<p>Data for all applications with the same name will be merged in the New Relic UI, so set this carefully. New Relic <b>highly recommends</b> that you replace the default name with a descriptive name to avoid confusion and unintended aggregation of data.</p>
+
+	<div class="callout-tip">
+	<p>For <a href="/docs/agents/nodejs-agent/hosting-services/nodejs-agent-microsoft-azure">Azure users</a>, the Node.js agent will use <code>APP_POOL_ID</code> if it is set, so you can use the name you chose for your Azure Web Server without setting it twice.</p>
+	</div>
+	</dd>
+	<dt id="license">license_key <span style="color: red">(REQUIRED)</span></dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>String</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>(none)</td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_LICENSE_KEY</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>This setting is required. Your New Relic <a href="/docs/accounts-partnerships/accounts/account-setup/license-key">license key</a>. For example, <code>license_key: '<var>40HexadecimalCharacters</var>'</code>.</p>
+	</dd>
+	<dt id="agent-enabled">agent_enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ENABLED</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Set to <code>false</code> to stop the agent from starting up. This is useful when debugging your code requires temporarily disabling the agent. It prevents the agent from bootstrapping its instrumentation or setting up all its pieces, which prevents the agent from starting up and connecting to New Relic's servers.</p>
+	</dd>
+	<dt id="allow_all_headers">allow_all_headers</dt>
+	<dd>
+	<p>If <code>true</code>, enables capture of all HTTP headers, except for those filtered by <code>exclude</code> rules. If <code>false</code>, collected headers are limited to those defined in <a href="/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-attributes">Node.js agent attributes</a>.</p>
+
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>false</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<div class="callout-caution">
+	<p>Any header-related include/exclude rules must be in camelCase form to be filtered.</p>
+	</div>
+	</dd>
+	<dt .apdex_t="" id="apdex">apdex_t <span style="color: red">(DEPRECATED)</span></dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Number</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>0.100</code></td>
+			</tr>
+			<tr>
+				<th><a href="#server-side">Server-side label</a></th>
+				<td><code>Apdex T</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Set your Apdex T <a href="https://docs.newrelic.com/docs/apm/new-relic-apm/apdex/changing-your-apdex-settings">via the New Relic UI</a>.</p>
+	</dd>
+	<dt id="certificates">certificates</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array of strings</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>(none)</td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Additional certificates to trust for SSL connections, specified as an array of strings in PEM format. This affects both connections to an HTTPS proxy and connections to New Relic.</p>
+
+	<div class="callout-tip">
+	<p>You can also configure the agent to read its certificates from a file:</p>
+
+	<pre>
+certificates: [ fs.readFileSync('<var>myca</var>.crt', {encoding: '<var>utf8</var>'}) ]</pre>
+	</div>
+	</dd>
+	<dt id="high_security">high_security</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>false</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_HIGH_SECURITY</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>When set to <code>true</code>, enables <a href="/docs/accounts-partnerships/accounts/security/high-security#version2description">high security v2</a>. You must also enable the <a href="#ssl"><code>ssl</code></a> setting and <a href="/docs/accounts-partnerships/accounts/security/high-security#version2enabled">enable high security in the UI</a>.</p>
+	</dd>
+	<dt id="host">host</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>String</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>collector.newrelic.com</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_HOST</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<div class="callout-important">
+	<p>Do not edit this value unless New Relic Support asks you to change it.</p>
+	</div>
+
+	<p>Hostname for the <a href="/docs/accounts-partnerships/education/getting-started-new-relic/glossary#collector">New Relic collector</a> to connect to the Internet; for example, <code>host: 'collector.newrelic.com'</code>.</p>
+	</dd>
+	<dt id="labels">labels</dt>
+	<dd>
+	<p>Use <a href="/docs/apm/new-relic-apm/maintenance/labels-categories-organize-your-apps-servers">labels and categories to organize your apps</a>. Specify your labels as objects or a semicolon-delimited string of colon-separated pairs (for example, <code><var>Server</var>:<var>One</var>;<var>Data Center</var>:<var>Primary</var></code>).</p>
+
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Object or string</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>(none)</td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_LABELS</code></td>
+			</tr>
+		</tbody>
+	</table>
+	</dd>
+	<dt id="port">port</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Integer</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>443</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_PORT</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<div class="callout-important">
+	<p>Do not edit this value unless New Relic Support asks you to change it.</p>
+	</div>
+
+	<p>Port number to connect to the New Relic collector; for example, <code>port: 443</code>.</p>
+	</dd>
+	<dt id="proxy">proxy</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>String</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>(none)</td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_PROXY_URL</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p id="proxy_url">A URL specifying the proxy server to connect to the Internet. For example, <code>proxy: 'http://<var>user</var>:<var>pass</var>@<var>10.0.0.1</var>:<var>8000</var>/'</code>.</p>
+
+	<div class="callout-important">
+	<p>The <code>proxy</code> config file setting overrides the other config file proxy settings (<code>proxy_host</code>, <code>proxy_port</code>, <code>proxy_user</code>, <code>proxy_pass</code>) if used. Similarly, the <code>NEW_RELIC_PROXY_URL</code> environment variable overrides the other environment variable proxy settings (<code>NEW_RELIC_PROXY_HOST</code>, <code>NEW_RELIC_PROXY_PORT</code>, <code>NEW_RELIC_PROXY_USER</code>, and <code>NEW_RELIC_PROXY_PASS</code>) if used.</p>
+	</div>
+	</dd>
+	<dt id="proxy_host">proxy_host</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>String</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>(none)</td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_PROXY_HOST</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Hostname or IP address of the proxy server to connect to the Internet.</p>
+	</dd>
+	<dt id="proxy_pass">proxy_pass</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>String</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>(none)</td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_PROXY_PASS</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Password for authenticating to the proxy server. The agent supports only basic HTTP authentication.</p>
+	</dd>
+	<dt id="proxy_port">proxy_port</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>String</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>(none)</td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_PROXY_PORT</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Port number of the proxy server to connect to the Internet.</p>
+	</dd>
+	<dt id="proxy_user">proxy_user</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>String</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>(none)</td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_PROXY_USER</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>User name for authenticating to the proxy server. The agent supports only basic HTTP authentication.</p>
+	</dd>
+	<dt id="ssl">ssl <span style="color: red">(DEPRECATED)</span></dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_USE_SSL</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>The agent communicates with New Relic via HTTPS by default, and New Relic <a href="/docs/apis/rest-api-v2/troubleshooting/301-response-rest-api-calls">requires HTTPS</a> for all traffic to New Relic APM and the New Relic REST API. When enabled, the agent uses SSL to connect to the <a href="/docs/accounts-partnerships/education/getting-started-new-relic/glossary#collector">New Relic collector</a>. Must be <code>true</code> to enable <a href="#high_security"><code>high_security</code></a>.</p>
+
+	<div class="callout-caution">
+	<p>By default the agent is compliant with <a href="/docs/accounts-partnerships/accounts/security/high-security#version1descritpion">high security v1</a>. However, if you disable <code>ssl</code> and enable <a href="#params"><code>capture_params</code></a>, the agent can exit high security mode, which prevents the agent from connecting with high-security accounts. If high security mode fails, the log files show an error message such as <code>ERROR Account Security Violation</code>.</p>
+	</div>
+	</dd>
+</dl>
+
+<h2 id="logging_config">Logging variables</h2>
+
+<p>This section defines the Node.js agent variables in the order they typically appear in the <code>logging: {</code> section of your app's <code>newrelic.js</code> configuration file.</p>
+
+<dl class="clamshell-list">
+	<dt id="log-enabled">enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>String</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code> (<code>false</code> in <code>serverless_mode</code>)</td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_LOG_ENABLED</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Enables or disables agent specific logging.</p>
+	</dd>
+	<dt id="log_level">level</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>String</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>info</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_LOG_LEVEL</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Defines the level of detail recorded in the agent logs. From least detail to most detail, possible values are <code>fatal</code>, <code>error</code>, <code>warn</code>, <code>info</code>, <code>debug</code>, or <code>trace</code>.</p>
+
+	<div class="callout-caution">
+	<p>Do not use <code>debug</code> or <code>trace</code> logging unless New Relic Support asks you to use them. These levels of logging can generate excessive overhead. For most situations, use <code>info</code>.</p>
+	</div>
+	</dd>
+	<dt id="log">filepath</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>String</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>process.cwd()</code> plus <code>newrelic_agent.log</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_LOG</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Complete path to the New Relic agent log, including the filename. Defaults to <code>filepath: require('path').join(process.cwd(), 'newrelic_agent.log')</code>. The agent will shut down the process if it cannot create this file. The agent creates a log file with the same permissions as the parent Node.js agent process.</p>
+
+	<ul>
+		<li>To write all logging to <b>stdout</b>, set this to <code>stdout</code>.</li>
+		<li>To write all logging to <b>stderr</b>, set this to <code>stderr</code>.</li>
+	</ul>
+	</dd>
+</dl>
+
+<h2 id="audit_log">Audit logging</h2>
+
+<p>This section defines the Node.js agent variables in the order they typically appear in the <code>audit_log: {</code> section of your app's <code>newrelic.js</code> configuration file.</p>
+
+<dl class="clamshell-list">
+	<dt id="audit_log-enabled">enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>false</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_AUDIT_LOG_ENABLED</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>When enabled, the agent logs the payloads it sends to the collector. This data is included in the main log file even when logging level is set to the lowest level.</p>
+	</dd>
+	<dt id="endpoints">endpoints</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>Empty array (include all types)</td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_AUDIT_LOG_ENDPOINTS</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>The agent sends several different types of data to the collector in separate payloads. By default, all of them are included in the log file. This option makes it possible to limit logging only to specific types of data.</p>
+
+	<p>Valid values include:</p>
+
+	<ul>
+		<li><code>agent_settings</code></li>
+		<li><code>analytic_event_data</code></li>
+		<li><code>connect</code></li>
+		<li><code>custom_event_data</code></li>
+		<li><code>error_data</code></li>
+		<li><code>error_event_data</code></li>
+		<li><code>metric_data</code></li>
+		<li><code>preconnect</code></li>
+		<li><code>shutdown</code></li>
+		<li><code>span_event_data</code></li>
+		<li><code>sql_trace_data</code></li>
+		<li><code>transaction_sample_data</code></li>
+	</ul>
+	</dd>
+</dl>
+
+<h2 id="api_config">API configuration</h2>
+
+<p>This section allows you to choose which API methods are enabled. Each configuration option allows you to modularly enable API methods that are responsible for sending custom information to New Relic.</p>
+
+<div class="callout-important">
+<p>All of these are set to <code>false</code> when the agent is in high security mode.</p>
+</div>
+
+<dl class="clamshell-list">
+	<dt id="custom-attributes">custom_attributes_enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td>
+				<p><code>NEW_RELIC_API_CUSTOM_ATTRIBUTES</code></p>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>This option enables <a href="/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#add-custom-param"><code>newrelic.addCustomAttribute</code></a> and <a href="/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#add-custom-params"><code>newrelic.addCustomAttributes</code></a>.</p>
+	</dd>
+	<dd></dd>
+	<dt id="custom-events">custom_events_enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_API_CUSTOM_EVENTS</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>This option enables <a href="/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#record_custom_event"><code>recordCustomEvent</code></a>.</p>
+	</dd>
+	<dt id="notice-error">notice_error_enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_API_NOTICE_ERROR</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>This option enables <a href="/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#noticeError"><code>newrelic.noticeError</code></a>.</p>
+	</dd>
+</dl>
+
+<h2 id="node-js-attributes">Attributes</h2>
+
+<p>This section defines the variables for <a href="/docs/agents/nodejs-agent/attributes/nodejs-agent-attributes">Node.js agent attributes</a> in the order they typically appear in the <code>attributes: {</code> section of your app's <code>newrelic.js</code> configuration file.</p>
+
+<div class="callout-caution">
+<p>Any header-related include/exclude rules must be in camelCase form to be filtered.</p>
+</div>
+
+<dl class="clamshell-list">
+	<dt id="attributes_enabled">enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ATTRIBUTES_ENABLED</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>If <code>true</code>, enables capture of attributes for all destinations.</p>
+	</dd>
+	<dt id="attributes_exclude">exclude</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>[]</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ATTRIBUTES_EXCLUDE</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Prefix of attributes to exclude from all destinations. Allows <code>*</code> as wildcard at end.</p>
+	</dd>
+	<dt id="attributes_include">include</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>[]</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ATTRIBUTES_INCLUDE</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Prefix of attributes to include from all destinations. Allows <code>*</code> as wildcard at end.</p>
+	</dd>
+	<dt id="attributes_include_enabled">include_enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ATTRIBUTES_INCLUDE_ENABLED</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>When <code>true</code>, patterns may be added to the <a href="/docs/agents/nodejs-agent/attributes/nodejs-agent-attributes#cfg-attributes-include"><code>attributes.include</code></a> list.</p>
+	</dd>
+</dl>
+
+<h2 id="error_config">Error collector variables</h2>
+
+<p>You can <a href="/docs/agents/manage-apm-agents/agent-data/manage-errors-apm-collect-ignore-mark-expected">manage how error are handled</a> in New Relic APM. This section defines the Node.js agent variables in the order they typically appear in the <code>error_collector: {</code> section of your app's <code>newrelic.js</code> configuration file.</p>
+
+<dl class="clamshell-list">
+	<dt id="error_collector">enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ERROR_COLLECTOR_ENABLED</code></td>
+			</tr>
+			<tr>
+				<th><a href="#server-side">Server-side label</a></th>
+				<td><code>Enable error collection?</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>When enabled, the agent collects <a href="/docs/apm/applications-menu/events/viewing-apm-errors-error-traces">error traces</a> from your app.</p>
+	</dd>
+	<dt id="error_ignore">ignore_status_codes</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>404</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES</code></td>
+			</tr>
+			<tr>
+				<th><a href="#server-side">Server-side label</a></th>
+				<td><code>Ignore these status codes</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Comma-delimited list of HTTP status codes for the error collector to ignore.</p>
+
+	<div class="callout-caution">
+	<p>Errors recorded using <a href="/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#noticeError">newrelic.noticeError</a> do not obey this configuration value.</p>
+	</div>
+	</dd>
+	<dt id="error_ignore">ignore_classes</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array|Object</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>[]</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERRORS</code></td>
+			</tr>
+			<!-- 
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES</code></td>
+			</tr>
+ --><!-- 
+			<tr>
+				<th><a href="#server-side">Server-side label</a></th>
+				<td><code>Ignore these status codes</code></td>
+			</tr>
+ -->
+		</tbody>
+	</table>
+	<!-- <p>Comma-delimited list of HTTP status codes for the error collector to ignore.</p> -->
+
+	<p>Comma-delimited list of javascript error types/classes for the error collector to ignore.</p>
+
+	<p>The following configuration</p>
+
+	<pre>
+    /* ... */
+    error_collector: {
+        ignore_classes: ["ReferenceError"]
+    }    
+    /* ... */
+</pre>
+
+	<p>Would ignore all reference errors.</p>
+
+	<div class="callout-caution">
+	<p>Errors recorded using <a href="/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#noticeError">newrelic.noticeError</a> do not obey this configuration value.</p>
+	</div>
+	</dd>
+	<dt id="error_ignore">ignore_messages</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Object</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>{}</code></td>
+			</tr>
+			<!-- 
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES</code></td>
+			</tr>
+ --><!-- 
+			<tr>
+				<th><a href="#server-side">Server-side label</a></th>
+				<td><code>Ignore these status codes</code></td>
+			</tr>
+ -->
+		</tbody>
+	</table>
+	<!-- <p>Comma-delimited list of HTTP status codes for the error collector to ignore.</p> -->
+
+	<p>A javascript object describing a list of javascript classes tied to javascript error messages for the collector to ignore. The following configuration.</p>
+
+	<pre>
+    /* ... */
+    error_collector: {
+        /* ... */
+        ignore_messages: {"Error":["Undefined"],"Error":["Out of time"]}
+        /* ... */
+    }    
+    /* ... */
+</pre>
+
+	<p>Would ignore all errors of type Error, with the exact (case-sensative) message strings of "Undefined" and "Out of time".</p>
+
+	<div class="callout-caution">
+	<p>Errors recorded using <a href="/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#noticeError">newrelic.noticeError</a> do not obey this configuration value.</p>
+	</div>
+	</dd>
+	<dt id="error_ignore">expected_status_codes</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>[]</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERROR_CODES</code></td>
+			</tr>
+			<!-- 
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES</code></td>
+			</tr>
+ --><!-- 
+			<tr>
+				<th><a href="#server-side">Server-side label</a></th>
+				<td><code>Ignore these status codes</code></td>
+			</tr>
+ -->
+		</tbody>
+	</table>
+	<!-- <p>Comma-delimited list of HTTP status codes for the error collector to ignore.</p> -->
+
+	<p>Comma-delimited list of HTTP status codes for the error collector to mark as expected.</p>
+
+	<div class="callout-caution">
+	<p>Errors recorded using <a href="/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#noticeError">newrelic.noticeError</a> do not obey this configuration value.</p>
+	</div>
+	</dd>
+	<dt id="error_ignore">expected_classes</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>[]</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ERROR_COLLECTOR_EXPECTED_ERRORS</code></td>
+			</tr>
+			<!-- 
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES</code></td>
+			</tr>
+ --><!-- 
+			<tr>
+				<th><a href="#server-side">Server-side label</a></th>
+				<td><code>Ignore these status codes</code></td>
+			</tr>
+ -->
+		</tbody>
+	</table>
+	<!-- <p>Comma-delimited list of HTTP status codes for the error collector to ignore.</p> -->
+
+	<p>The following configuration</p>
+
+	<pre>
+    /* ... */
+    error_collector: {
+        expected_classes: ["ReferenceError"]
+    }    
+    /* ... */
+</pre>
+
+	<p>Would mark all reference errors as expected.</p>
+
+	<p></p>
+
+	<div class="callout-caution">
+	<p>Errors recorded using <a href="/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#noticeError">newrelic.noticeError</a> do not obey this configuration value.</p>
+	</div>
+	</dd>
+	<dt id="error_ignore">expected_messages</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Object</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>{}</code></td>
+			</tr>
+			<!-- 
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ERROR_COLLECTOR_IGNORE_ERROR_CODES</code></td>
+			</tr>
+ --><!-- 
+			<tr>
+				<th><a href="#server-side">Server-side label</a></th>
+				<td><code>Ignore these status codes</code></td>
+			</tr>
+ -->
+		</tbody>
+	</table>
+	<!-- <p>Comma-delimited list of HTTP status codes for the error collector to ignore.</p> -->
+
+	<p>A javascript object describing a list of javascript classes tied to javascript error messages for the collector to ignore. The following configuration.</p>
+
+	<pre>
+    /* ... */
+    error_collector: {
+        /* ... */
+        expected_messages: {"Error":["Undefined"],"Error":["Out of time"]}
+        /* ... */
+    }    
+    /* ... */
+</pre>
+
+	<p>Would mark all errors of type Error with the exact (case-sensative) message strings of "Undefined" and "Out of time" as expected.</p>
+
+	<div class="callout-caution">
+	<p>Errors recorded using <a href="/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#noticeError">newrelic.noticeError</a> do not obey this configuration value.</p>
+	</div>
+	</dd>
+	<dt id="error_attributes_enabled">attributes.enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_ENABLED</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>If <code>true</code>, the agent captures attributes from error collection.</p>
+
+	<div class="callout-caution">
+	<p>Any header-related include/exclude rules must be in camelCase form to be filtered.</p>
+	</div>
+	</dd>
+	<dt id="error_attributes_exclude">attributes.exclude</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>[]</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_EXCLUDE</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Prefix of attributes to exclude from error collection. Allows <code>*</code> as wildcard at end.</p>
+	</dd>
+	<dt id="error_attributes_include">attributes.include</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>[]</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ERROR_COLLECTOR_ATTRIBUTES_INCLUDE</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Prefix of attributes to include in error collection. Allows <code>*</code> as wildcard at end.</p>
+	</dd>
+</dl>
+
+<h2 id="tx_tracer_config">Transaction tracer variables</h2>
+
+<p>The agent groups your requests into <a href="/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction">transactions</a>, which are used to:</p>
+
+<ul>
+	<li>Visualize where your app spends its time (in transaction breakdowns).</li>
+	<li>Identify slow requests.</li>
+	<li>Group metrics.</li>
+	<li>Isolate other issues, such as slow <a href="/docs/apm/applications-menu/monitoring/databases-slow-queries-dashboard">database performance</a>.</li>
+</ul>
+
+<p>This section defines the Node.js agent variables in the order they typically appear in the <code>transaction_tracer: {</code> section of your app's <code>newrelic.js</code> configuration file.</p>
+
+<div class="callout-important">
+<p>Do not use brackets <code>[<var>suffix</var>]</code> at the end of your transaction name. New Relic automatically strips brackets from the name. Instead, use parentheses <code>(<var>suffix</var>)</code> or other symbols if needed.</p>
+</div>
+
+<dl class="clamshell-list">
+	<dt id="tracer_enabled">enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_TRACER_ENABLED</code></td>
+			</tr>
+			<tr>
+				<th><a href="#server-side">Server-side label</a></th>
+				<td><code>Enable transaction tracing?</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>When enabled, the agent collects slow <a href="/docs/apm/transactions/transaction-traces/transaction-traces">transaction traces</a>.</p>
+	</dd>
+	<dt id="explain_threshold">explain_threshold</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Integer</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>500</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_EXPLAIN_THRESHOLD</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Minimum query duration (in milliseconds) for a transaction to be eligible for <a href="/docs/apm/applications-menu/monitoring/viewing-slow-query-details">slow queries</a> in <a href="/docs/apm/transactions/transaction-traces/transaction-traces">transaction traces</a>.</p>
+	</dd>
+	<dt id="record-sql">record_sql</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>String (<code>off</code>, <code>obfuscated</code>, or <code>raw</code>)</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>off</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_RECORD_SQL</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>This option affects both <a href="#slow-queries">slow queries</a> and <code>record_sql</code> for transaction traces. It can have one of three values: <code>off</code>, <code>obfuscated</code>, or <code>raw</code>.</p>
+
+	<p>When set to <code>off</code> no slow queries will be captured, and backtraces and SQL will not be included in transaction traces. If set to <code>raw</code> or <code>obfuscated</code>, the agent sends raw or obfuscated SQL and a slow query sample to the <a href="/docs/accounts-partnerships/education/getting-started-new-relic/glossary#collector">collector</a>. The agent may also send SQL when other criteria are met, such as when <code>slow_sql.enabled</code> is set.</p>
+	</dd>
+	<dt id="tracer_top">top_n</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Integer</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>20</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_TRACER_TOP_N</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Defines the maximum number of requests eligible for <a href="/docs/apm/transactions/transaction-traces/transaction-traces">transaction traces</a>.</p>
+
+	<p>Transactions are named based on the request, and <code>top_n</code> refers to the "top <var>n</var> slowest transactions" grouped by these names. The module replaces a recorded trace with a new trace only if the new trace is slower than the previous slowest trace of that name. The default value for this setting is <code>top_n: 20</code>, because the <a href="/docs/apm/transactions/transaction-traces/transaction-traces"><strong>Transactions</strong> page</a> also defaults to the 20 slowest transactions.</p>
+
+	<p>The Node.js agent captures at least five different slow transactions in the first harvest cycle after start up. It will also reset and capture different transactions if no slow transactions have been captured for the last five <a href="/docs/apm/new-relic-apm/getting-started/glossary#harvest-cycle">harvest cycles</a>. This allows you to see more information about more of your app's request paths, at the possible cost of not focusing on the absolutely slowest request for that harvest cycle.</p>
+
+	<div class="callout-tip">
+	<p>To record the absolute slowest transaction over the last minute, you can set <code>top_n: 0</code> or <code>top_n: 1</code>. However, this causes one very slow route to dominate your transaction traces.</p>
+	</div>
+	</dd>
+	<dt id="tracer_threshold">transaction_threshold</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Integer or <code>apdex_f</code></td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>apdex_f</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_TRACER_THRESHOLD</code></td>
+			</tr>
+			<tr>
+				<th><a href="#server-side">Server-side label</a></th>
+				<td><code>Threshold</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Threshold of web transaction response time in seconds beyond which a <a href="/docs/accounts-partnerships/education/getting-started-new-relic/glossary#transaction">transaction</a> is eligible for <a href="/docs/apm/transactions/transaction-traces/transaction-traces">transaction tracing</a>. The default value is <code>apdex_f</code>; this sets the trace threshold to four times your application's <a href="/docs/accounts-partnerships/education/getting-started-new-relic/glossary#apdex_t">Apdex T</a>. You can also enter a specific time value in milliseconds.</p>
+
+	<div class="examplebox">
+	<p><b>Example: Threshold set to <code>apdex_f</code></b></p>
+
+	<p>The default <code>apdex_t</code> is 100 milliseconds. If your transaction threshold is set to <code>apdex_f</code>, a "slow" transaction is 400 milliseconds.</p>
+	</div>
+	</dd>
+	<dt id="hide-internals">hide_internals</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_HIDE_INTERNALS</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>The agent uses a small amount of CPU in order to hide internal properties that are attached to the web application. If you change this configuration to <code>false</code>, it may slightly decrease your agent overhead, but it could also have an impact on the performance of the agent.</p>
+	</dd>
+	<dt id="hide-attributes-enabled">attributes.enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_TRANSACTION_TRACER_ATTRIBUTES_ENABLED</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>If <code>true</code>, the agent captures attributes from transaction traces.</p>
+
+	<div class="callout-caution">
+	<p>Any header-related include/exclude rules must be in camelCase form to be filtered.</p>
+	</div>
+	</dd>
+	<dt id="hide-attributes-exclude">attributes.exclude</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>[]</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_TRANSACTION_TRACER_ATTRIBUTES_EXCLUDE</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Prefix of attributes to exclude from transaction traces. Allows <code>*</code> as wildcard at end.</p>
+	</dd>
+	<dt id="hide-attributes-include">attributes.include</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>[]</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_TRANSACTION_TRACER_ATTRIBUTES_INCLUDE</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Prefix of attributes to include in transaction traces. Allows <code>*</code> as wildcard at end.</p>
+	</dd>
+</dl>
+
+<h2 id="rules_config">Rules variables</h2>
+
+<p>This section defines the Node.js agent variables in the order they typically appear in the <code>rules: {</code> section of your app's <code>newrelic.js</code> configuration file.</p>
+
+<dl class="clamshell-list">
+	<dt id="rules_names">name</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Strings or regular expressions</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>(none)</td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_NAMING_RULES</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>A comma-delimited list of rules to match incoming request URLs and name the associated New Relic transaction. Uses the format:</p>
+
+	<pre>
+	name: [
+	{pattern: '<var>STRING_OR_REGEX</var>', name: '<var>NAME</var>'},
+
+	{pattern: '<var>STRING_OR_REGEX</var>', name: '<var>NAME</var>'}
+
+	],
+</pre>
+
+	<p>Both parameters are required. For strings, you must escape control characters. You do not need to escape control characters in regular expressions. Additional attributes are ignored.</p>
+
+	<p>Regular expressions support JavaScript-style capture groups, and names use <code>$1</code>-style replacement strings. Regular expressions only find the first matching result; subsequent matches are ignored. For more information, see <a href="/docs/agents/nodejs-agent/api-guides/nodejs-agent-api#ignoring">Node.js transaction naming API</a>.</p>
+
+	<p>For the <code>NEW_RELIC_NAMING_RULES</code> environment variable, pass the rules as comma-delimited JSON object literals:</p>
+
+	<pre>
+NEW_RELIC_NAMING_RULES='{"pattern":"<var>^t</var>","name":"<var>u</var>"},{"pattern":"<var>^u</var>","name":"<var>t</var>"}'</pre>
+	</dd>
+	<dt id="rules_ignore">ignore</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Strings or regular expressions</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>
+				<p>Regular expression to match socket.io long-polling requests ("^\/socket\.io\/.*\/xhr-polling/").</p>
+				</td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_IGNORING_RULES</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Define a list of request URLs you want the agent to ignore. Specify the list as patterns, which can be strings or regular expressions.</p>
+	</dd>
+	<dt id="enforce_backstop">enforce_backstop</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ENFORCE_BACKSTOP</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<div class="callout-caution">
+	<p>Do not change this setting unless you understand <a href="/docs/features/metric-grouping-issues">metric grouping issues</a>.</p>
+	</div>
+
+	<p>When enabled, the agent renames transactions that are not affected by other naming logic (such as the API, rules, or metric normalization rules) to <code><var>NormalizedUri</var>/*</code>. If you set this to <code>false</code>, the agent sets transaction names to <code><var>Uri/path/to/resource</var></code>.</p>
+	</dd>
+</dl>
+
+<h2 id="tx_events">Transaction events variables</h2>
+
+<p>This section defines the Node.js agent variables in the order they typically appear in the <code>transaction_events: {</code> section of your app's <code>newrelic.js</code> configuration file.</p>
+
+<dl class="clamshell-list">
+	<dt id="tx_events_enabled">enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>When enabled, the agent sends transaction events to New Relic. This event data includes transaction timing, transaction name, and any custom parameters. If this is disabled, the agent does not collect this data or send it to Insights.</p>
+	</dd>
+	<dt id="tx_events_max_samples_stored">max_samples_stored</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Integer</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>10000</td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Defines the maximum number of events the agent collects per minute. If there are more than this number, the agent collects a statistical sampling.</p>
+
+	<p>We do not recommend configuring past 10k. The server will cap data at 10k per-minute.</p>
+
+	<div class="callout-important">
+	<p>This configuration had different behavior in agent versions lower than 6.0.0. See <a href="#tx_events_max_samples_stored_legacy">max_samples_stored (DEPRECATED)</a> for agent versions 5.x or lower.</p>
+	</div>
+	</dd>
+	<dt id="tx_events_max_samples_stored_legacy">max_samples_stored <span style="color: red">(DEPRECATED)</span></dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Integer</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>20000</td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Defines the maximum number of events the agent stores if it is unable to communicate with the <a href="/docs/accounts-partnerships/education/getting-started-new-relic/glossary#collector">New Relic collector</a>. The values from the previous <a href="/docs/accounts-partnerships/education/getting-started-new-relic/glossary#harvest-cycle">harvest cycle</a> will be merged into the next one, with this option limiting the maximum number. Make sure this number is greater than <code><a href="#tx_events_max_samples_per_minute">max_samples_per_minute</a></code>; for example, set it to twice as much. Consider your memory overhead before increasing this value.</p>
+
+	<div class="callout-caution">
+	<p>This configuration has different behavior starting with agent version 6.0.0 and a new recommended maximum. See <a href="#tx_events_max_samples_stored">max_samples_stored</a> for agent versions 6.x or higher.</p>
+	</div>
+	</dd>
+	<dt id="tx_events_max_samples_per_minute">max_samples_per_minute <span style="color: red">(DEPRECATED)</span></dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Integer</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>10000</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Defines the maximum number of events the agent collects per minute. If there are more than this number, the agent collects a statistical sampling.</p>
+
+	<div class="callout-caution">
+	<p>This configuration has been replaced with max_samples_stored starting with version 6.0.0 of the agent. See <a href="#tx_events_max_samples_stored">max_samples_stored</a> for 6.x or later agents.</p>
+	</div>
+	</dd>
+	<dt id="tx-attributes-enabled">attributes.enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_ENABLED</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>If <code>true</code>, the agent captures attributes from transaction events.</p>
+
+	<div class="callout-caution">
+	<p>Any header-related include/exclude rules must be in camelCase form to be filtered.</p>
+	</div>
+	</dd>
+	<dt id="tx-attributes-exclude">attributes.exclude</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>[]</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_EXCLUDE</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Prefix of attributes to exclude from transaction events. Allows <code>*</code> as wildcard at end.</p>
+	</dd>
+	<dt id="tx-attributes-include">attributes.include</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>[]</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_TRANSACTION_EVENTS_ATTRIBUTES_INCLUDE</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Prefix of attributes to include in transaction events. Allows <code>*</code> as wildcard at end.</p>
+	</dd>
+</dl>
+
+<h2 id="browser-variables">Browser monitoring variables</h2>
+
+<p>This section defines the Node.js agent variables in the order they typically appear in the <code>browser_monitoring: {</code> section of your app's <code>newrelic.js</code> configuration file.</p>
+
+<dl class="clamshell-list">
+	<dt id="browser">enable</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_BROWSER_MONITOR_ENABLE</code></td>
+			</tr>
+			<tr>
+				<th><a href="#server-side">Server-side label</a></th>
+				<td><code>Enable browser monitoring?</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Generate JavaScript headers for New Relic Browser instrumentation. Although this defaults to <code>true</code>, the agent doesn't inject the New Relic Browser JavaScript unless you have <a href="/docs/browser/new-relic-browser/installation-configuration/adding-apps-new-relic-browser">enabled New Relic Browser</a>. Even if you have enabled New Relic Browser and <a href="/docs/agents/nodejs-agent/supported-features/page-load-timing-nodejs#procedures">added the Browser timing header</a>, you can <a href="/docs/agents/nodejs-agent/supported-features/page-load-timing-nodejs#disabling">disable Browser for your app</a> by setting this to <code>false</code>.</p>
+	</dd>
+	<dt id="browser-debug">debug</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>false</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_BROWSER_MONITOR_DEBUG</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>If <code>true</code>, request un-minified sources from the server.</p>
+	</dd>
+	<dt id="browser-debug-enabled">attributes.enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>false</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_BROWSER_MONITORING_ATTRIBUTES_ENABLED</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>If <code>true</code>, the agent sends custom attributes to New Relic Browser monitoring.</p>
+
+	<div class="callout-caution">
+	<p>Any header-related include/exclude rules must be in camelCase form to be filtered.</p>
+	</div>
+	</dd>
+	<dt id="browser-debug-exclude">attributes.exclude</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>[]</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_BROWSER_MONITORING_ATTRIBUTES_EXCLUDE</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Prefix of attributes to exclude from Browser monitoring. Allows <code>*</code> as wildcard at end.</p>
+	</dd>
+	<dt id="browser-debug-include">attributes.include</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>[]</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_BROWSER_MONITORING_ATTRIBUTES_INCLUDE</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Prefix of attributes to include in Browser monitoring. Allows <code>*</code> as wildcard at end.</p>
+	</dd>
+</dl>
+
+<h2 id="custom_events">Custom Insights events variables</h2>
+
+<p>This section defines the Node.js agent variables in the order they typically appear in the <code>custom_insights_events: {</code> section of your app's <code>newrelic.js</code> configuration file. Currently there are no environment variables for custom Insights events.</p>
+
+<dl class="clamshell-list">
+	<dt id="custom_events_enabled">enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>When enabled, the agent sends custom Insights events recorded with <a href="/docs/agents/nodejs-agent/supported-features/nodejs-agent-api#custom-events-api"><code>recordCustomEvent()</code></a> to <a href="/docs/insights/new-relic-insights/adding-querying-data/inserting-custom-events-insights-api">New Relic Insights</a>. If this is disabled, the agent does not collect this data or send it to New Relic Insights.</p>
+	</dd>
+	<dt id="custom_events_max_samples_stored">max_samples_stored</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Integer</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>1000</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Defines the maximum number of custom events the agent collects per minute. If the number of custom events exceeds this limit, the agent collects a statistical sampling.</p>
+
+	<div class="callout-important">
+	<p>Increasing this limit increases memory usage.</p>
+	</div>
+	</dd>
+</dl>
+
+<h2 id="slow-queries">Slow queries variables</h2>
+
+<p>This section defines the Node.js agent variables in the order they typically appear in the <code>slow_sql: {</code> section of your app's <code>newrelic.js</code> configuration file. These options control behavior for slow queries, but do not affect SQL nodes in transaction traces.</p>
+
+<dl class="clamshell-list">
+	<dt id="slow-sql-enabled">enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>false</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_SLOW_SQL_ENABLED</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>When enabled, the agent collects <a href="/docs/apm/applications-menu/monitoring/viewing-slow-query-details">slow query details</a>.</p>
+	</dd>
+	<dt id="slow-sql-max-samples">max_samples</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Integer</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>10</td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_MAX_SQL_SAMPLES</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Defines the maximum number of slow queries the agent collects per minute. The agent discards additional queries after the limit is reached.</p>
+
+	<div class="callout-important">
+	<p>Increasing this limit increases memory usage.</p>
+	</div>
+	</dd>
+</dl>
+
+<h2 id="custom-hostnames">Custom hostname variables</h2>
+
+<p>This section defines the Node.js agent variables in the order they typically appear in the <code>process_host: {</code> section of your app's <code>newrelic.js</code> configuration file. These options control behavior regarding the host display name in the New Relic APM UI.</p>
+
+<dl class="clamshell-list">
+	<dt id="custom-hostnames-display">display_name</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>String of 255 bytes or less</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>(none)</td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_PROCESS_HOST_DISPLAY_NAME</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Specify a custom hostname for <a href="/docs/apm/new-relic-apm/maintenance/add-rename-remove-hosts#display_name">display in the New Relic UI</a>. If you do not set this field, New Relic will continue to use the default hostname found by calling <code>os.hostname()</code>.</p>
+
+	<ul id="custom_hostname">
+		<li>If you use the default hostname settings, New Relic finds the hostname through <code>os.hostname()</code>.</li>
+		<li>If this call fails, New Relic uses the host's IP as the name.</li>
+		<li>If you set <code>ipv_preference: 4</code> or <code>ipv_preference: 6</code>, you can select the type of IP address (IPv4 or IPv6) that appears in the New Relic UI.</li>
+	</ul>
+	</dd>
+	<dt id="custom-hostnames-ipv">ipv_preference</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Integer (<code>4</code> or <code>6</code>)</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>4</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_IPV_PREFERENCE</code></td>
+			</tr>
+		</tbody>
+	</table>
+	</dd>
+</dl>
+
+<h2 id="environment-variable-overrides">Environment variable overrides</h2>
+
+<p>This section defines two configuration options only available with environment variables. These overrides are not used in most configurations.</p>
+
+<dl class="clamshell-list">
+	<dt id="home">NEW_RELIC_HOME</dt>
+	<dd>
+	<p>Path to the directory containing <code>newrelic.js</code>. This is available only as an environment variable. You cannot set it in your config file.</p>
+
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>String</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td>(none)</td>
+			</tr>
+		</tbody>
+	</table>
+	</dd>
+	<dt id="no_file">NEW_RELIC_NO_CONFIG_FILE</dt>
+	<dd>
+	<p>Avoid using <code>NEW_RELIC_NO_CONFIG_FILE</code> because:</p>
+
+	<ul>
+		<li>Environment variables override <code>newrelic.js</code> settings anyway.</li>
+		<li>Most configurations depend on the existence of <code>newrelic.js</code>.</li>
+		<li>Some log messages assume a config file exists.</li>
+	</ul>
+
+	<p>If used, this prevents the agent from reading configuration settings from <code>newrelic.js</code>. To use this setting, you must configure <b>all</b> key settings by using environment variables.</p>
+
+	<p>This is available only as an environment variable. You cannot set it in your config file.</p>
+
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>False</code></td>
+			</tr>
+		</tbody>
+	</table>
+	</dd>
+</dl>
+
+<h2 id="datastore-tracer">Datastore tracer variables</h2>
+
+<p>This section defines the Node.js agent variables in the order they typically appear in the <code>datastore_tracer</code> section of your app's <code>newrelic.js</code> configuration file. These options control behavior for collecting datastore instance metrics.</p>
+
+<dl class="clamshell-list">
+	<dt id="datastore-instance-enabled">instance_reporting.enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>When enabled, the agent collects datastore instance metrics (such as host and port) for <a href="/docs/agents/nodejs-agent/supported-features/nodejs-instance-level-database-information">some database drivers</a>. These are reported on slow query traces and transaction traces.</p>
+	</dd>
+	<dt id="datastore-name-enabled">database_name_reporting.enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>When enabled, the agent collects database name on slow query traces and transaction traces for <a href="/docs/agents/nodejs-agent/supported-features/nodejs-instance-level-database-information">some database drivers</a>.</p>
+	</dd>
+</dl>
+
+<h2 id="cross-app-tracing">Cross application tracing</h2>
+
+<p>The Node.js agent variables that control <a href="/docs/apm/transactions/cross-application-traces/introduction-cross-application-traces">cross application tracing</a> typically appear in the <code>cross_application_tracer</code> section of your app's <code>newrelic.js</code> configuration file:</p>
+
+<dl class="clamshell-list">
+	<dt id="cat-enabled">enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>When set to <code>true</code>, allows tracing of transactions across more than one New Relic-monitored applications.</p>
+	</dd>
+</dl>
+
+<h2 id="err-message-redact">Error message redaction variables</h2>
+
+<p>The Node.js agent variables that control error message redaction appear in the <code>allow_raw_exception_messages</code> section of your app's <code>newrelic.js</code> configuration file:</p>
+
+<dl class="clamshell-list">
+	<dt id="allow-raw-enabled">enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_ALLOW_RAW_EXCEPTION_MESSAGES_ENABLED</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>When <code>false</code>, the agent will redact the messages of captured errors.</p>
+	</dd>
+</dl>
+
+<h2 id="distributed-tracing">Distributed tracing</h2>
+
+<div class="callout-important">
+<p>Enabling distributed tracing disables <a href="#cross-app-tracing">cross application tracing</a>, and has effects on other New Relic APM features. Before enabling, read the <a href="/docs/transition-guide-distributed-tracing">transition guide</a>.</p>
+
+<p>Requires <a href="/docs/agents/nodejs-agent/installation-configuration/upgrade-nodejs-agent">Node.js agent version 4.7.0 or higher</a>.</p>
+</div>
+
+<p><a href="/docs/intro-distributed-tracing">Distributed tracing</a> lets you see the path that a request takes as it travels through a distributed system. When configuring via the config file, place the following option in the <code>distributed_tracing</code> section.</p>
+
+<p>When distributed tracing is enabled, you can collect <a href="/docs/apm/distributed-tracing/ui-data/span-event">span events</a>.</p>
+
+<dl class="clamshell-list"><!-- ********** enabled ********** -->
+	<dt id="dt-enabled">enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>false</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_DISTRIBUTED_TRACING_ENABLED</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Set this to <code>true</code> to enable distributed tracing.</p>
+
+	<p>For example, to enable this in the config file, you would use:</p>
+
+	<pre>
+distributed_tracing: {
+   enabled: true
+}</pre>
+	</dd>
+	<dt id="dt-exclude-newrelic-header">exclude_newrelic_header</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>false</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Set this to <code>true</code> to exclude the New Relic header that is attached to outbound requests, and instead only rely on W3C Trace Context Headers for distributed tracing. If this is <code>false</code> then both types of headers are used.</p>
+
+	<p>For example, to enable this in the config file, you would use:</p>
+
+	<pre>
+distributed_tracing:{
+   enabled: true,
+   exclude_newrelic_header: true
+}</pre>
+	</dd>
+</dl>
+
+<h2 id="span-events">Span events</h2>
+
+<p><a href="/docs/apm/distributed-tracing/ui-data/span-event">Span events</a> are reported for <a href="#distributed-tracing">distributed tracing</a>. Distributed tracing must be enabled to report span events. Span configuration is set in the <code>span_events</code> stanza. Options include:</p>
+
+<dl class="clamshell-list">
+	<dt id="span-events-enabled">enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_SPAN_EVENTS_ENABLED</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Turns reporting of span events on or off.</p>
+	</dd>
+	<dt id="span-events-attributes-enabled">attributes.enabled</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Boolean</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>true</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_SPAN_EVENTS_ATTRIBUTES_ENABLED</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>This setting can be used to turn reporting of attributes on or off for span events. If <code>attributes.enabled</code> at the root level is <code>false</code>, no attributes will be sent to span events regardless on how this is set.</p>
+	</dd>
+	<!-- ********** span_events.attributes.include ********** -->
+	<dt id="span-events-attributes-include">attributes.include</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>[]</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_SPAN_EVENTS_ATTRIBUTES_INCLUDE</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>If attributes are enabled for span events, all attribute keys found in this list will be attached to span events. For more information, see the <a href="/docs/apm/other-features/attributes/agent-attributes">agent attribute rules</a>.</p>
+	</dd>
+	<!-- ********** span_events.attributes.exclude ********** -->
+	<dt id="span-events-attributes-exclude">attributes.exclude</dt>
+	<dd>
+	<table class="specs">
+		<tbody>
+			<tr>
+				<th>Type</th>
+				<td>Array</td>
+			</tr>
+			<tr>
+				<th>Default</th>
+				<td><code>[]</code></td>
+			</tr>
+			<tr>
+				<th><a href="#environment-variables">Environ variable</a></th>
+				<td><code>NEW_RELIC_SPAN_EVENTS_ATTRIBUTES_EXCLUDE</code></td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>All attribute keys found in this list will not be sent with span events. For more information, see the <a href="/docs/apm/other-features/attributes/agent-attributes">agent attribute rules</a>.</p>
+	</dd>
+</dl>
+
+<h2 id="more_help">For more help</h2>

--- a/src/content/docs/browser/get-started/intro-to-browser.md
+++ b/src/content/docs/browser/get-started/intro-to-browser.md
@@ -1,0 +1,305 @@
+---
+title: Introduction to New Relic Browser
+path: /browser/get-started/introduction-new-relic-php
+contentType: basicDoc
+templateKey: BasicDocPageTemplate
+topics:
+  - Browser
+  - Browser agent
+  - Get started
+moreInfoLinks:
+- link: "/docs/agents/php-agent/troubleshooting/no-data-appears-php"
+  text: "No data appears (PHP)"
+metaDescription: "For an overview of New Relic's Browser agent read this."
+---
+<p>New Relic Browser provides deep visibility and insight into how your users are interacting with your application or website. New Relic Browser measures page load timing, also known as real user monitoring (RUM), but it goes far beyond that to measure:</p>
+
+<ul>
+	<li>Individual session performance</li>
+	<li>AJAX requests</li>
+	<li><a href="/docs/browser/single-page-app-monitoring/get-started/welcome-single-page-app-monitoring">SPA-architecture route changes</a></li>
+	<li>JavaScript errors</li>
+</ul>
+
+<p>With this added functionality, New Relic extends real user monitoring to include the entire life cycle of a page or a view. And with <a href="/docs/insights/use-insights-ui/manage-account-data/insights-data-retention#access">access to New Relic Insights</a>, you can gather and visualize your <a href="/docs/insights/insights-data-sources/default-attributes/browser-default-attributes-insights">browser data</a>, then analyze what that data says about your business.</p>
+
+<div class="callout-tip">
+<p>If you're ready to get started with browser monitoring, see <a href="/docs/browser/new-relic-browser/installation/install-new-relic-browser-agent">Install Browser</a>.</p>
+</div>
+
+<h2 id="life-cycle-monitoring">Full life cycle monitoring</h2>
+
+<p>Many websites contain dynamic content that is loaded after the initial page has finished loading, and complex JavaScript code increases the need for error reporting. After you <a href="/docs/browser/new-relic-browser/installation-configuration/adding-apps-new-relic-browser">install New Relic Browser</a>, you get visibility into your users' entire experience, from the front end of your app to its backend performance. You can also see the individual interactions within user's webpage session (up to ten minutes).</p>
+
+<p>Expanding far beyond legacy real user monitoring solutions, New Relic Browser monitors full page life cycle data, well beyond the initial page load. The UI also shows events throughout the individual user's session, allowing you to pinpoint problem areas and easily identify solutions.</p>
+
+<p>For each end user page load, New Relic captures:</p>
+
+<ul>
+	<li>Time spent in the front end (browser)</li>
+	<li>Time spent in the back end (network and web app)</li>
+	<li>Geographic origin</li>
+	<li>Browser type and version, and operating system</li>
+</ul>
+
+<p>For customers monitoring <a href="/docs/browser/single-page-app-monitoring/get-started/welcome-single-page-app-monitoring">single-page application (SPA) architectures</a>, New Relic captures route change data and associated AJAX requests.</p>
+
+<p>Browser presents app data in charts, maps, and tables. You can view the data globally across all users and see it sliced and diced by webpage, browser, user session, and location. In addition, New Relic Browser enhances New Relic's original real user monitoring (RUM) feature with expanded functionality, detailed charts, and focused data.</p>
+
+<h2 id="enhanced-features">Feature comparison</h2>
+
+<p id="standard-features">New Relic Browser includes standard features for all <a href="http://newrelic.com/browser-monitoring/pricing" target="_blank" title="Link opens in a new window">subscription levels</a>. With a New Relic Browser Pro subscription, you can capitalize on additional, enhanced features.</p>
+
+<table>
+	<thead>
+		<tr>
+			<th width="200">New Relic Browser page</th>
+			<th>Features</th>
+			<th style="width:100px">Lite</th>
+			<th style="width:100px">Pro</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr id="features-overview">
+			<td>
+			<p><a href="/docs/browser/new-relic-browser/getting-started/browser-overview-website-performance-glance">Browser <strong>Overview</strong></a>:</p>
+
+			<p>Your website's performance at a glance</p>
+			</td>
+			<td>
+			<p>For both Lite and Pro subscriptions, the <strong>Overview</strong> summary charts show:</p>
+
+			<ul>
+				<li><a href="/docs/browser/new-relic-browser/page-load-timing-resources/page-load-timing-process">Page load timing</a></li>
+				<li>Comparative <a href="/docs/apm/new-relic-apm/apdex/apdex-measuring-user-satisfaction">Apdex scores</a> for browsers and app servers</li>
+				<li>Throughput by browser type</li>
+			</ul>
+
+			<p>In addition, Pro subscriptions include charts with:</p>
+
+			<ul>
+				<li>Recent session traces of page load and user interaction events</li>
+				<li>JavaScript error rate</li>
+				<li>AJAX response time</li>
+			</ul>
+
+			<p>Links from the <strong>Overview</strong> page allow you to explore even deeper levels.</p>
+			</td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i><br />
+			(some)</td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i><br />
+			(all)</td>
+		</tr>
+		<tr>
+			<td id="features-sessions">
+			<p><strong><a href="/docs/browser/new-relic-browser/browser-pro-features/session-traces-exploring-webpages-life-cycle">Session traces</a></strong>:</p>
+
+			<p>Timeline of page load and user interaction events during a webpage's full life cycle</p>
+			</td>
+			<td>
+			<p>This detailed and intuitive visualization of all events in the user's session can help pinpoint problem areas and easily identify solutions. The <strong>Session traces</strong> page provides:</p>
+
+			<ul>
+				<li>Summary information with links to specific sessions</li>
+				<li>A heat map with events and times to view directly</li>
+				<li>An expanded waterfall of events (up to ten minutes) to drill down into details</li>
+				<li>Color-coded legend of the webpage's life cycle</li>
+				<li>Zoom tools for quick navigation from the big picture to an individual interaction</li>
+			</ul>
+			</td>
+			<td></td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i></td>
+		</tr>
+		<tr id="features-ajax">
+			<td>
+			<p><strong><a href="/docs/browser/new-relic-browser/browser-pro-features/ajax-dashboard-identifying-time-consuming-calls">AJAX calls</a></strong>:</p>
+
+			<p>Time-consuming or failing AJAX calls affecting webpage performance</p>
+			</td>
+			<td>
+			<p>The <strong>AJAX</strong> page helps identify page load timing problems from the users' experience when you have time-consuming AJAX calls to update parts of the webpage. Chart data includes:</p>
+
+			<ul>
+				<li>Total time percentages for <a href="/docs/browser/new-relic-browser/getting-started/url-whitelists-grouping-browser-metrics">URL-based metrics</a></li>
+				<li>Throughput</li>
+				<li>Response time</li>
+				<li>Average data transfer rates</li>
+				<li>Status code patterns</li>
+			</ul>
+			</td>
+			<td></td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i></td>
+		</tr>
+		<tr id="features-js-errors">
+			<td>
+			<p><strong><a href="/docs/browser/new-relic-browser/browser-pro-features/js-errors-dashboard-examining-errors-over-time">JavaScript errors</a></strong>:</p>
+
+			<p>Browser errors in production over time</p>
+			</td>
+			<td>
+			<p>To help identify problems you may not have tested for, or problems your users are experiencing that you may not have easily seen, the <strong>JS errors</strong> page shows:</p>
+
+			<ul>
+				<li>Number of times errors occurred during a given time range</li>
+				<li>Automatically detected error patterns</li>
+				<li>Event log showing asynchronous activity leading up to an error</li>
+				<li>Stack trace error details when available</li>
+				<li>Un-minified stack traces with source map upload</li>
+			</ul>
+			</td>
+			<td></td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i></td>
+		</tr>
+		<tr id="features-pageviews">
+			<td>
+			<p><strong><a href="/docs/browser/new-relic-browser/additional-standard-features/page-views-insights-your-sites-popularity">Page views</a></strong>:</p>
+
+			<p>Insights into your site's popularity</p>
+			</td>
+			<td>
+			<p>Drill down into detailed information about:</p>
+
+			<ul>
+				<li>Top webpages viewed (with <a href="/docs/browser/new-relic-browser/getting-started/url-whitelists-grouping-browser-metrics">URL-based metrics</a>)</li>
+				<li>Timing and throughput details</li>
+				<li>Links to <a href="/docs/browser/new-relic-browser/browser-pro-features/session-traces-exploring-webpages-life-cycle">session traces</a> (Pro)</li>
+			</ul>
+
+			<p>In addition, use New Relic's <a href="/docs/synthetics/new-relic-synthetics/administration/compare-page-load-performance-browser-synthetics">comparative charting feature</a> for a direct page load time comparison between real user (Browser) interactions and trends appearing in <a href="/docs/synthetics/new-relic-synthetics/getting-started/introduction-new-relic-synthetics">New Relic Synthetics</a> monitors.</p>
+			</td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i></td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i></td>
+		</tr>
+		<tr>
+			<td>
+			<p><strong><a href="https://docs.newrelic.com/docs/browser/new-relic-browser/page-load-timing-resources/pageviewtiming-async-or-dynamic-page-details">Page View Timing</a>:</strong></p>
+
+			<p>A look into your user's perception of your site's performance</p>
+			</td>
+			<td>
+			<p>The <a href="https://docs.newrelic.com/attribute-dictionary/pageview?attribute_name=&amp;events_tids%5B%5D=10061"><code>PageViewTiming</code> event</a> provides a more real-time delivery mechanism that does not have a dependency on any other event. The additional metrics:</p>
+
+			<ul>
+				<li>First, first contentful & largest contentful paint</li>
+				<li>First input delay</li>
+				<li>First interaction</li>
+			</ul>
+
+			<p>Helps you understand how users experience your site, both from visual and responsiveness standpoints.</p>
+			</td>
+			<td class="fcenter"></td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i></td>
+		</tr>
+		<tr id="features-spa-pageviews">
+			<td>
+			<p><strong><a href="/docs/browser/single-page-app-monitoring/browser-ui/view-spa-data-new-relic-browser">SPA views</a></strong>:</p>
+
+			<p>Monitoring for single-page app (SPA) architectures</p>
+			</td>
+			<td>
+			<p>When SPA monitoring is enabled, Browser's <b>Page views</b> page shows you:</p>
+
+			<ul>
+				<li>Data for route changes</li>
+				<li>Data for initial page loads</li>
+				<li>Synchronous and asynchronous activity associated with browser interactions</li>
+				<li>Page load timing that measures all associated asynchronous processes, not just page load events</li>
+			</ul>
+			</td>
+			<td></td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i></td>
+		</tr>
+		<tr id="features-geography">
+			<td>
+			<p><strong><a href="/docs/browser/new-relic-browser/additional-standard-features/geography-webpage-performance-location">Geography</a></strong>:</p>
+
+			<p>Webpage performance by location</p>
+			</td>
+			<td>
+			<p>Color-coded Apdex scores and other data show your end users' experience around the world or in a specific region or state.</p>
+
+			<p>In addition, Pro users can use the enhanced <a href="/docs/browser/new-relic-browser/browser-pro-features/filterable-geography-webpage-metrics-location"><b>Filterable geography</b> page</a> to:</p>
+
+			<ul>
+				<li>Filter and drill down into performance metrics.</li>
+				<li>Use your mouse to select or zoom in and out of any location on the map.</li>
+				<li>Explore heat map details.</li>
+			</ul>
+
+			<p>The Pro subscription level of visual detail is especially useful for professionals in IT and Operations to make business decisions about peering agreements and CDN usage.</p>
+			</td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i> (some)</td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i> (all)</td>
+		</tr>
+		<tr id="features-browsers-page">
+			<td>
+			<p><strong><a href="/docs/browser/new-relic-browser/additional-standard-features/browsers-problem-patterns-type-or-location">Browsers</a></strong>:</p>
+
+			<p>Problem patterns by browser type or platform</p>
+			</td>
+			<td>
+			<p>Explore your end users' experience with your app segmented by the browser they use, such as Google Chrome, Mozilla Firefox, Microsoft Internet Explorer, and Apple Safari. You can drill down to view:</p>
+
+			<ul>
+				<li>Top browsers by throughput</li>
+				<li>Average page load time by platform type (mobile, desktop, and other)</li>
+				<li>Selected browser type by version (for example, Chrome 31, 32, 33, etc.)</li>
+			</ul>
+
+			<p>This helps you quickly determine whether problems with page load timing may be related to a specific browser type or platform, or whether the problem is more widespread.</p>
+			</td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i></td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i></td>
+		</tr>
+		<tr id="features-settings">
+			<td>
+			<p><strong><a href="/docs/browser/new-relic-browser/getting-started/browser-settings">Settings</a></strong>:</p>
+
+			<p>UI options for browser monitoring</p>
+			</td>
+			<td>
+			<p>Turn the New Relic Browser product on or off, including the option to enable or disable specific features. For example, you can:</p>
+
+			<ul>
+				<li>Select specific Apdex settings and countries for browsers.</li>
+				<li>Enable or disable the AJAX and JavaScript errors reporting features.</li>
+				<li>Maintain an <a href="/docs/browser/new-relic-browser/configuration/group-browser-metrics-urls#hierarchy">allow list of URL segments</a>.</li>
+				<li>Monitor or block specific <a href="/docs/browser/new-relic-browser/installation-configuration/monitor-or-block-specific-domains">domains</a>.</li>
+				<li>View your Browser app's alert conditions.</li>
+			</ul>
+			</td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i></td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i></td>
+		</tr>
+		<tr id="insights">
+			<td>
+			<p><strong><a href="/docs/insights">New Relic Insights</a></strong>:</p>
+
+			<p>Access to Insights features</p>
+			</td>
+			<td>
+			<p>With <a href="/docs/insights/use-insights-ui/manage-account-data/insights-data-retention#access">access to New Relic Insights</a>, you get access to powerful features for the <a href="https://docs.newrelic.com/docs/insights/insights-data-sources/default-data/browser-default-events-insights">default Browser event data</a>, including:</p>
+
+			<ul>
+				<li>Run custom queries of your data using a <a href="/docs/insights/nrql-new-relic-query-language/using-nrql/introduction-nrql">SQL-like query language</a>.</li>
+				<li>Create <a href="/docs/insights/use-insights-ui/manage-dashboards/create-edit-copy-insights-dashboards">custom dashboards</a> of your data.</li>
+			</ul>
+			</td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i> (some)</td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i></td>
+		</tr>
+		<tr id="distributed-tracing">
+			<td>
+			<p><strong><a href="/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing">Distributed tracing</a></strong>:</p>
+
+			<p>See complete request paths</p>
+			</td>
+			<td>
+			<p>With <a href="/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing">access to New Relic distributed tracing</a>, you can see the connection between front-end activity and back-end activity. You can see across a full transaction, from browser activity, to time spent in network, to back-end activity.</p>
+			</td>
+			<td class="fcenter"></td>
+			<td class="fcenter"><i class="fa fa-check"><span>[check icon]</span></i></td>
+		</tr>
+	</tbody>
+</table>
+

--- a/src/content/docs/infrastructure/install-infrastructure/linux-agent-running-modes.md
+++ b/src/content/docs/infrastructure/install-infrastructure/linux-agent-running-modes.md
@@ -1,0 +1,248 @@
+---
+title: Linux agent running modes
+path: /infrastructure/install/linux/linux-agent-running-modes
+contentType: basicDoc
+templateKey: BasicDocPageTemplate
+topics:
+  - Infrastructure
+  - Install
+  - Linux
+moreInfoLinks:
+- link: "/docs/agents/php-agent/troubleshooting/no-data-appears-php"
+  text: "No data appears (PHP)"
+metaDescription: "For installation of New Relic's Infra agent for linux read this."
+---
+<p>The Infrastructure agent for Linux environments can run as root, privileged, or unprivileged user, which are described below:</p>
+
+<table>
+	<thead>
+		<tr>
+			<th style="width:150px">Mode</th>
+			<th>Overview</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>Root</td>
+			<td>
+			<p>Installed by default. Runs as <code>root</code> and has total access to all the system metrics and inventory.</p>
+			</td>
+		</tr>
+		<tr>
+			<td>Privileged</td>
+			<td>
+			<p>Runs as a non-privileged user named <code>nri-agent</code> that is created automatically during the installation process.</p>
+
+			<ul>
+			</ul>
+
+			<p>Normal users do not have <code>READ</code> access to all the system metrics, so the agent will not be able to report all the metrics of the root mode. However, privileged mode can collect more metrics than unprivileged mode, including most of the inventory. This is because at installation time, the <code>/usr/bin/newrelic-infra</code> executable is granted with <a href="http://man7.org/linux/man-pages/man7/capabilities.7.html"><code>CAP_SYS_PTRACE</code> and <code>CAP_DAC_READ_SEARCH</code> kernel capabilities</a>.</p>
+			</td>
+		</tr>
+		<tr>
+			<td>Unprivileged</td>
+			<td>
+			<p>Runs as a non-privileged user named <code>nri-agent</code> that is created automatically during the installation process.</p>
+
+			<p>This mode is the most restricted. Normal users do not have <code>READ</code> access to all the system metrics, so the agent will not be able to report all the metrics of the root or privileged modes.</p>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="mode-metrics">Metrics and inventory provided</h2>
+
+<p>The agent provides different metrics and inventory depending on the running mode:</p>
+
+<table>
+	<thead>
+		<tr>
+			<th style="width:150px">Mode</th>
+			<th>Metrics and inventory</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>Root</td>
+			<td>All of the documented <a href="https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/data-instrumentation">data and instrumentation values</a>.</td>
+		</tr>
+		<tr>
+			<td>Privileged</td>
+			<td>
+			<p>All of the values from root mode, except:</p>
+
+			<ul>
+				<li>SELinux inventory: This depends on the <code>semodule</code> command, which requires root access.</li>
+				<li>Docker process metrics: These are not enabled by default. However, you can manually enable them by giving access rights to the <code>nri-agent</code> user.</li>
+			</ul>
+			</td>
+		</tr>
+		<tr>
+			<td>Unprivileged</td>
+			<td>
+			<p>All of the values from privileged mode, except:</p>
+
+			<p><strong>Process samples</strong> do not report these metrics:</p>
+
+			<ul>
+				<li>File descriptor count</li>
+				<li>I/O read bytes per second</li>
+				<li>I/O read count per second</li>
+				<li>I/O total read bytes</li>
+				<li>I/O total read count</li>
+				<li>I/O total write bytes</li>
+				<li>I/O total write count</li>
+				<li>I/O write bytes per second</li>
+				<li>I/O write count per second</li>
+			</ul>
+
+			<p>The following <strong>inventory sources</strong> are not reported:</p>
+
+			<ul>
+				<li><code>config/sshd</code></li>
+				<li><code>kernel/sysctl</code></li>
+				<li><code>packages/rpm</code></li>
+				<li><code>packages/dpkg</code></li>
+				<li><code>services/pidfile</code> on SysV-based distributions</li>
+			</ul>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="mode-integrations">Run integrations</h2>
+
+<p>As root, integrations will run as usual. When running as privileged or unprivileged user, integrations will execute properly, although some custom integrations (for example, built by customers or technical sales staff) that depend on access to root may need additional configuration.</p>
+
+<dl class="clamshell-list">
+	<dt id="">On-host integrations</dt>
+	<dd>
+	<p>In general, on-host integrations will run with the non-root agent as long as the <code>nri-agent</code> has permissions on the integration cache files.</p>
+
+	<p>The default path where the integration cache files are stored is <code>/tmp</code>. To change the path, set the environment variable <code>NRIA_CACHE_PATH</code>. In this situation, use the following instructions to target the provided cache path folder instead of <code>/tmp</code>.</p>
+
+	<table>
+		<thead>
+			<tr>
+				<th style="width:150px">On-host integrations</th>
+				<th>Cache path folder</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>Apache</td>
+				<td>
+				<pre>
+sudo chown nri-agent:nri-agent -R /tmp/nr-apache.json</pre>
+				</td>
+			</tr>
+			<tr>
+				<td>Cassandra</td>
+				<td>
+				<pre>
+sudo chown nri-agent:nri-agent -R /tmp/nr-integrations</pre>
+				</td>
+			</tr>
+			<tr>
+				<td>MySQL</td>
+				<td>
+				<pre>
+sudo chown nri-agent:nri-agent -R /tmp/nr-mysql.json</pre>
+				</td>
+			</tr>
+			<tr>
+				<td>Nginx</td>
+				<td>
+				<pre>
+sudo chown nri-agent:nri-agent -R /tmp/nr-nginx.json</pre>
+				</td>
+			</tr>
+			<tr>
+				<td>Redis</td>
+				<td>
+				<pre>
+sudo chown nri-agent:nri-agent -R /tmp/nr-redis.json</pre>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+	</dd>
+	<dt id="">Custom integrations</dt>
+	<dd>
+	<p>If your custom integration doesn't require root privileges, then it’s compatible with the rootless mode. To run it, you just need to change the <code>owner:group</code> of the cache file as explained above.</p>
+
+	<p>If your integration requires to be executed with a privileged user, you can use the <code>integration_user</code> argument in the configuration integration.</p>
+	</dd>
+</dl>
+
+<h2 id="set-mode">Set the running mode for your agent</h2>
+
+<div class="callout-tip">
+<p>When deciding which run mode to use, consider how much data you want to be able to collect and analyze, or how much data you want to restrict.</p>
+</div>
+
+<p>For default and <a href="/docs/infrastructure/install-configure-infrastructure/linux-installation/assisted-install-infrastructure-linux">assisted installations</a>, you can set the running mode by including the <code>NRIA_MODE</code> environment variable set to either <code>ROOT</code>, <code>PRIVILEGED</code>, or <code>UNPRIVILEGED</code>.</p>
+
+<p>For <a href="https://docs.newrelic.com/docs/infrastructure/install-configure-infrastructure/linux-installation/manual-install-infrastructure-linux">manual installations</a>, follow the instructions described in our docs.</p>
+
+<h2 id="install-agent">Switch running modes</h2>
+
+<dl class="clamshell-list">
+	<dt id="root-rootless">From root to privileged/unprivileged</dt>
+	<dd>
+	<p>To switch the running mode <strong>from root to privileged or unprivileged</strong>, follow the installation/update instructions in this doc.</p>
+	</dd>
+	<dt id="rootless-root">From privileged/unprivileged to any other mode</dt>
+	<dd>
+	<p>To change the running mode <strong>from privileged or unprivileged to any other mode: </strong></p>
+
+	<ol>
+		<li>
+		<p>Follow these steps:</p>
+
+		<table>
+			<tbody>
+				<tr>
+					<td style="width:150px"><strong>Debian/Ubuntu</strong></td>
+					<td>
+					<p></p>
+
+					<pre>
+dpkg --purge newrelic-infra</pre>
+
+					<p>OR</p>
+
+					<pre>
+sudo apt-get remove --purge newrelic-infra</pre>
+					</td>
+				</tr>
+				<tr>
+					<td><strong>Centos/Suse/RedHat/Amazon</strong></td>
+					<td>
+					<pre>
+rpm -e newrelic-infra</pre>
+
+					<p>OR</p>
+
+					<pre>
+sudo yum remove newrelic-infra</pre>
+
+					<p>OR</p>
+
+					<pre>
+sudo zypper rm newrelic-infra</pre>
+					</td>
+				</tr>
+			</tbody>
+		</table>
+		</li>
+		<li>
+		<p>After making sure the agent is completely removed, reinstall the agent with the selected mode.</p>
+		</li>
+	</ol>
+	</dd>
+</dl>
+
+<h2 id="update">Update the agent</h2>
+
+<p>Follow standard procedures to <a href="/docs/update-infrastructure-agent">update the Infrastructure agent</a>.</p>

--- a/src/content/docs/synthetics/scripted-monitors/scripted-browser-reference.md
+++ b/src/content/docs/synthetics/scripted-monitors/scripted-browser-reference.md
@@ -1,0 +1,1265 @@
+---
+title: Synthetics scripted browser reference (monitor versions 0.5.0+)
+path: /synthetics/scripted-monitors/scripted-browser-reference
+contentType: basicDoc
+templateKey: BasicDocPageTemplate
+topics:
+  - Synthetics
+  - Scripted Monitors
+moreInfoLinks:
+- link: "/docs/agents/php-agent/troubleshooting/no-data-appears-php"
+  text: "No data appears (PHP)"
+metaDescription: "For configuration of New Relic's synthetics monitors read this."
+---
+<div class="callout-important">
+<p>This document describes scripted browser functions available for Synthetics monitor versions 0.5.x or higher. If you are using older monitor versions, see the <a href="/docs/synthetics/new-relic-synthetics/scripting-monitors/synthetics-scripted-browser-reference">monitor version 0.4.0 and lower documentation</a>.</p>
+</div>
+
+<p>To determine a monitor's version: Go to <b><a href="https://synthetics.newrelic.com">synthetics.newrelic.com</a> > (select a monitor) > Settings > General</b>. For more on monitor versions and runtime differences, see <a href="/docs/synthetics/new-relic-synthetics/scripting-monitors/scripted-monitor-runtime-environment">Runtime environments</a>.</p>
+
+<h2 id="selenium">Selenium Webdriver APIs</h2>
+
+<p>The New Relic Synthetics <a href="/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers">scripted browsers</a> provide access to the <a href="http://seleniumhq.github.io/selenium/docs/api/javascript/index.html">Selenium Webdriver APIs 3.6.0</a> for monitor version 0.6.x and <a href="http://seleniumhq.github.io/selenium/docs/api/javascript/index.html">Selenium Webdriver APIs 3.5.0</a> for monitor version 0.5.x via the variables <code>$driver</code> and <code>$browser</code>. In particular:</p>
+
+<ul>
+	<li><code>$driver</code> provides all the exports from the <code>selenium-webdriver</code> module (for example, <code>ActionSequence</code>, <code>Button</code>, <code>By</code>, <code>WebElement</code>, etc.).</li>
+	<li><code>$browser</code> is a New Relic Synthetics instance of <code>selenium-webdriver.WebDriver()</code>. It exposes the main basic <code>WebDriver</code> APIs like <code>get()</code> and <code>findElement()</code>, as well as some Synthetics custom APIs.</li>
+</ul>
+
+<h2 id="structure">Top-level functions: Build your script</h2>
+
+<p>New Relic Synthetics calls top-level functions directly from your <code>$browser</code> instance. These provide a wide range of functionality that covers many basic scriptable actions.</p>
+
+<table>
+	<thead>
+		<tr>
+			<th style="width: 400px;">Function</th>
+			<th>Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr id="browser-actions">
+			<td>
+			<p><code>$browser.actions()</code></p>
+			</td>
+			<td>
+			<p>Creates a new action sequence using this driver. For a list of available actions, see <a href="#actionsequence">ActionSequence</a>.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-addHeader">
+			<td>
+			<p><code>$browser.addHeader(headerKey: <var>string</var>, headerValue: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Adds header <code><var>headerKey</var></code> with value <code><var>headerValue</var></code> to the runtime.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-addHeaders">
+			<td>
+			<p><code>$browser.addHeaders(headers: <var>?</var>)</code></p>
+			</td>
+			<td>
+			<p>Adds a map of headers to the runtime.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-deleteHeader">
+			<td>
+			<p><code>$browser.deleteHeader(header: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Deletes a specific header from the runtime.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-deleteHeaders">
+			<td>
+			<p><code>$browser.deleteHeaders(header: [<var>string</var>])</code></p>
+			</td>
+			<td>
+			<p>Deletes all headers in the argument from runtime.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-addHostnameToBlacklist">
+			<td>
+			<p><code>$browser.addHostnameToBlacklist(hostname: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Adds a hostname to your deny list. Allows using <a href="#wildcard-use">wildcards</a>.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-addHostnamesToBlacklist">
+			<td>
+			<p><code>$browser.addHostnamesToBlacklist(hostnameArr: [<var>string</var>])</code></p>
+			</td>
+			<td>
+			<p>Adds all hostnames in an array of arguments to your deny list. Allows using <a href="#wildcard-use">wildcards</a>.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-addHostnameToWhitelist">
+			<td>
+			<p><code>$browser.addHostnameToWhitelist(hostname: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Adds a hostname blocked by default in Synthetics to your allow list.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-addHostnamesToWhitelist">
+			<td>
+			<p><code>$browser.addHostnamesToWhitelist(hostnameArr: [<var>string</var>])</code></p>
+			</td>
+			<td>
+			<p>Adds all hostnames in the argument to your allow list.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-deleteHostnameFromBlacklist">
+			<td>
+			<p><code>$browser.deleteHostnameFromBlacklist(hostname: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Removes a hostname for this browser instance from your deny list.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-deleteHostnamesFromBlacklist">
+			<td>
+			<p><code>$browser.deleteHostnamesFromBlacklist(hostnameArr: [<var>string</var>])</code></p>
+			</td>
+			<td>
+			<p>Removes all hostnames in the argument from your deny list.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-deleteHostnameFromWhitelist">
+			<td>
+			<p><code>$browser.deleteHostnameFromWhitelist(hostnameArr: [<var>string</var>])</code></p>
+			</td>
+			<td>
+			<p>Removes a hostname for this browser instance from your allow list.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-deleteHostnamesFromWhitelist">
+			<td>
+			<p><code>$browser.deleteHostnamesFromWhitelist(hostnameArr: [<var>string</var>])</code></p>
+			</td>
+			<td>
+			<p>Removes all hostnames in the argument from your allow list for this browser instance.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-executeAsyncScript">
+			<td>
+			<p><code>$browser.executeAsyncScript(script: <var>?</var>, var_args: <var>?</var>)</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to execute asynchronous JavaScript in the context of the currently selected frame or window.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="browser-executeScript">
+			<td>
+			<p><code>$browser.executeScript(script: <var>?</var>, var_args: <var>?</var>)</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to execute JavaScript in the context of the currently selected frame or window.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="browser-findElement">
+			<td>
+			<p><code>$browser.findElement(locator: $driver.<var>Locator</var>)</code></p>
+			</td>
+			<td>
+			<p>Schedule a command to <a href="#locators">find an element on the page</a>. If not found, Synthetics will return an error.</p>
+
+			<p>Return value: WebElement</p>
+			</td>
+		</tr>
+		<tr id="browser-findElements">
+			<td>
+			<p><code>$browser.findElements(locator: $driver.<var>Locator</var>)</code></p>
+			</td>
+			<td>
+			<p>Schedule a command to <a href="#locators">search for multiple elements on the page</a>.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="browser-waitForAndFindElement">
+			<td>
+			<p><code>$browser.waitForAndFindElement(locator: $driver.<var>Locator</var> [, timeout: <var>number</var>)</code></p>
+			</td>
+			<td>
+			<p>Schedule a command to wait for and <a href="#locators">find an element on the page</a>, and another command to wait for it to be visible. If not found, Synthetics will return an error.</p>
+
+			<p>The timeout value is optional. It is applied separately to both tasks of finding the element and waiting for its visibility. This means at worst case, this method can take up to twice the provided timeout value. The default timeout value is 1000 ms (1 second).</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="browser-get">
+			<td>
+			<p><code>$browser.get(url: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Loads a webpage in a Synthetics browser.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="browser-getAllWindowHandles">
+			<td>
+			<p><code>$browser.getAllWindowHandles()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to retrieve the current list of available window handles.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="browser-getCapabilities">
+			<td>
+			<p><code>$browser.getCapabilities()</code></p>
+			</td>
+			<td>
+			<p>A promise that will resolve with the instance's capabilities.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="browser-getCurrentUrl">
+			<td>
+			<p><code>$browser.getCurrentUrl()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to retrieve the URL of the current page.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="browser-getHeaders">
+			<td>
+			<p><code>$browser.getHeaders()</code></p>
+			</td>
+			<td>
+			<p>Returns a map of currently configured headers.</p>
+
+			<p>Return value: map</p>
+			</td>
+		</tr>
+		<tr id="browser-getPageSource">
+			<td>
+			<p><code>$browser.getPageSource()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to retrieve the current page's source. The page source returned is a representation of the underlying DOM. Do not expect it to be formatted or escaped in the same way as the response sent from the web server.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="browser-getSession">
+			<td>
+			<p><code>$browser.getSession()</code></p>
+			</td>
+			<td>
+			<p>A promise for this client's session.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="browser-getTitle">
+			<td>
+			<p><code>$browser.getTitle()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to retrieve the current page's title.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="browser-getWindowHandle">
+			<td>
+			<p><code>$browser.getWindowHandle()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to retrieve the current window handle.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="browser-manage">
+			<td>
+			<p><code>$browser.manage()</code></p>
+			</td>
+			<td>
+			<p>The options interface for this instance. You can manage <a href="#options">cookies, timeouts, and other window options</a>.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-navigate">
+			<td>
+			<p><code>$browser.navigate()</code></p>
+			</td>
+			<td>
+			<p>The <a href="#navigate">navigation interface (history of browser functions)</a> for this instance.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-schedule">
+			<td>
+			<p><code>$browser.schedule(command: <var>?</var>, description: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to be executed by this driver's <code>CommandExecutor</code>.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="browser-sleep">
+			<td>
+			<p><code>$browser.sleep()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to make the driver sleep for the given amount of time.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="browser-switchTo">
+			<td>
+			<p><code>$browser.switchTo()</code></p>
+			</td>
+			<td>
+			<p>The target locator interface for this instance.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="browser-takeScreenshot">
+			<td>
+			<p><code>$browser.takeScreenshot()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to take a screenshot.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="browser-wait">
+			<td>
+			<p><code>$browser.wait(fn: $driver.<var>Condition</var>, timeout: <var>number</var>, opt_message: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Schedules a <a href="#until">command to wait for a condition to hold</a>, as defined by your supplied function.</p>
+
+			<p>Return value: WebElement</p>
+			</td>
+		</tr>
+		<tr id="browser-waitforpending">
+			<td>
+			<p><code>$browser.waitForPendingRequests(timeout: <var>number</var>)</code></p>
+			</td>
+			<td>
+			<p>Causes the script to wait for requests that have been initiated to return, up to the timeout. Useful for tracking non-blocking resources.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="wildcard-use">Deny list: Wildcard use</h2>
+
+<p>If you want to add domains to the deny list for your browser instance, the wildcards must match the URL syntax of the URL to be blocked.</p>
+
+<p>An overall <code>.com</code> deny list must contain these functions:</p>
+
+<table>
+	<thead>
+		<tr>
+			<th>Function</th>
+			<th style="width: 200px;">Blocking action</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr id="options-manage-addCookie">
+			<td>
+			<p><code>$browser.addHostnameToBlacklist('*.com');</code></p>
+			</td>
+			<td><code>a.com</code></td>
+		</tr>
+		<tr>
+			<td><code>$browser.addHostnameToBlacklist('*.*.com');</code></td>
+			<td><code>a.b.com</code></td>
+		</tr>
+		<tr>
+			<td><code>$browser.addHostnameToBlacklist('*.*.*.com');</code></td>
+			<td><code>a.b.c.com</code></td>
+		</tr>
+		<tr>
+			<td><code>$browser.addHostnameToBlacklist('www.*.com');</code></td>
+			<td><code>www.a.com</code></td>
+		</tr>
+		<tr>
+			<td><code>$browser.addHostnameToBlacklist('www.*.*.com');</code></td>
+			<td><code>www.a.b.com</code></td>
+		</tr>
+		<tr>
+			<td><code>$browser.addHostnameToBlacklist('www.*.*.*.com');</code></td>
+			<td><code>www.a.b.c.com</code></td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="options">Options: Manage the browser instance</h2>
+
+<p>These functions manage options for your browser instance, such as cookies, timeouts, and window size. Access these options through the <a href="#browser-manage"><code>$browser.manage()</code></a> function.</p>
+
+<table>
+	<thead>
+		<tr>
+			<th style="width: 400px;">Function</th>
+			<th>Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr id="options-manage-addCookie">
+			<td>
+			<p><code>$browser.manage().addCookie(spec: <font color="#000000"><span style="background-color: rgb(153, 221, 221);"><i>object</i></span></font>)</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to add a cookie.</p>
+
+			<p><code>spec</code> is a record object describing a browser cookie. For more information, see the <a href="http://seleniumhq.github.io/selenium/docs/api/javascript/module/selenium-webdriver/lib/webdriver_exports_Options.Cookie.html">Selenium documentation</a>.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="options-manage-deleteAllCookies">
+			<td>
+			<p><code>$browser.manage().deleteAllCookies()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to delete all cookies visible to the current page.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="options-manage-deleteCookie">
+			<td>
+			<p><code>$browser.manage().deleteCookie(name: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to delete the cookie with the given name. This command is a no-op if there is no cookie with the given name visible to the current page.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="options-manage-getCookie">
+			<td>
+			<p><code>$browser.manage().getCookie(name: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to retrieve the cookie with the given name. Returns null if there is no such cookie. The cookie will be returned as a JSON object as described by the WebDriver wire protocol.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="options-manage-getCookies">
+			<td>
+			<p><code>$browser.manage().getCookies()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to retrieve all cookies visible to the current page. New Relic Syntheticcs returns each cookie as a JSON object as described by the WebDriver wire protocol.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="options-manage-timeouts-implicitlyWait">
+			<td>
+			<p><code>$browser.manage().timeouts().implicitlyWait(ms: <var>number</var>)</code></p>
+			</td>
+			<td>
+			<p>Specifies the amount of time the driver should wait when searching for an element if it is not immediately present. Setting the wait timeout to <code>0</code> disables implicit waiting.</p>
+
+			<p>Be careful increasing the wait timeout, as it will increase test run time, especially with slower location strategies like XPath. Default is 10 seconds.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="options-manage-timeouts-pageLoadTimeout">
+			<td>
+			<p><code>$browser.manage().timeouts().pageLoadTimeout(ms: <var>number</var>)</code></p>
+			</td>
+			<td>
+			<p>Sets the amount of time to wait for a page load to complete before returning an error. If the timeout is negative, page loads may last up to 180 seconds. Default is 60 seconds.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="options-manage-timeouts-setScriptTimeout">
+			<td>
+			<p><code>$browser.manage().timeouts().setScriptTimeout(ms: <var>number</var>)</code></p>
+			</td>
+			<td>
+			<p>Sets the amount of time to wait, in milliseconds, for an asynchronous script to finish execution before returning an error. Default is 30 seconds.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="options-manage-window-getPosition">
+			<td>
+			<p><code>$browser.manage().window().getPosition()</code></p>
+			</td>
+			<td>
+			<p>Retrieves the window's current position, relative to the top left corner of the screen.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="options-manage-window-getSize">
+			<td>
+			<p><code>$browser.manage().window().getSize()</code></p>
+			</td>
+			<td>
+			<p>Retrieves the window's current size.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="options-manage-window-maximize">
+			<td>
+			<p><code>$browser.manage().window().maximize()</code></p>
+			</td>
+			<td>
+			<p>Maximizes the current window.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="options-manage-window-setPosition">
+			<td>
+			<p><code>$browser.manage().window().setPosition(x: <var>number</var>, y: <var>number</var>)</code></p>
+			</td>
+			<td>
+			<p>Repositions the current window.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="options-manage-window-setSize">
+			<td>
+			<p><code>$browser.manage().window().setSize(width: <var>number</var>, height: <var>number</var>)</code></p>
+			</td>
+			<td>
+			<p>Resizes the current window.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="locators">Locators: Find page elements</h2>
+
+<p>Locators are a collection of factory functions for creating <code>locator</code> instances. Locators find DOM elements, which can be passed to functions such as <a href="#browser-findElement"><code>$browser.findElement</code></a>. Call them through <code>$driver.By</code>.</p>
+
+<table>
+	<thead>
+		<tr>
+			<th style="width: 400px;">Function</th>
+			<th>Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr id="driver-by-className">
+			<td>
+			<p><code>$driver.By.className(className: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Locates an element that has a specific class name. The returned locator is equivalent to searching for elements with the CSS selector <code>.clazz</code>.</p>
+
+			<p>Return value: locator</p>
+			</td>
+		</tr>
+		<tr id="driver-by-css">
+			<td>
+			<p><code>$driver.By.css(cssName: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Locates an element using a CSS selector.</p>
+
+			<p>Return value: locator</p>
+			</td>
+		</tr>
+		<tr id="driver-by-id">
+			<td>
+			<p><code>$driver.By.id(id: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Locates an element by its ID.</p>
+
+			<p>Return value: locator</p>
+			</td>
+		</tr>
+		<tr id="driver-by-linkText">
+			<td>
+			<p><code>$driver.By.linkText(linkText: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Locates link elements whose visible text matches the given string.</p>
+
+			<p>Return value: locator</p>
+			</td>
+		</tr>
+		<tr id="driver-by-js">
+			<td>
+			<p><code>$driver.By.js(js: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Locates an element by evaluating a JavaScript expression.</p>
+
+			<p>Return value: locator</p>
+			</td>
+		</tr>
+		<tr id="driver-by-name">
+			<td>
+			<p><code>$driver.By.name(name: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Locates elements whose name attribute has the given value.</p>
+
+			<p>Return value: locator</p>
+			</td>
+		</tr>
+		<tr id="driver-by-partialLinkText">
+			<td>
+			<p><code>$driver.By.partialLinkText(partialLinkText: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Locates link elements whose <a href="#webElement-getText">getText</a> visible contains the given substring.</p>
+
+			<p>Return value: locator</p>
+			</td>
+		</tr>
+		<tr id="driver-by-tagName">
+			<td>
+			<p><code>$driver.By.tagName(tagName: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Locates elements with a given tag name. The returned locator is equivalent to using the <code>getElementsByTagName</code> DOM function.</p>
+
+			<p>Return value: locator</p>
+			</td>
+		</tr>
+		<tr id="driver-by-xpath">
+			<td>
+			<p><code>$driver.By.xpath(xpath: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Locates elements matching a XPath selector.</p>
+
+			<p>Return value: locator</p>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="webelement">WebElement: Interact with page elements</h2>
+
+<p>When a function such as <a href="#browser-findElement"><code>$browser.findElement</code></a> or <a href="#browser-waitForAndFindElement"><code>$browser.waitForAndFindElement</code></a> returns a WebElement reference, these functions can be used to interact with that element. For example, you can click on buttons, sent text to form inputs, and get attributes of elements to test.</p>
+
+<table>
+	<thead>
+		<tr>
+			<th style="width: 400px;">Function</th>
+			<th>Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr id="webElement-click">
+			<td>
+			<p><code>click()</code></p>
+			</td>
+			<td>
+			<p>Clicks on this element.</p>
+
+			<p>Return value: self reference</p>
+			</td>
+		</tr>
+		<tr id="webElement-sendKeys">
+			<td>
+			<p><code>sendKeys(var_args: <var>?</var>)</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to type a sequence on the DOM element represented by this instance.</p>
+
+			<p>Return value: WebElement</p>
+			</td>
+		</tr>
+		<tr id="webElement-getTagName">
+			<td>
+			<p><code>getTagName()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to query for the tag/node name of this element.</p>
+
+			<p>Return value: WebElement</p>
+			</td>
+		</tr>
+		<tr id="webElement-getCssValue">
+			<td>
+			<p><code>getCssValue(name: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to query for the computed style of the element represented by this instance. If the element inherits the named style from its parent, the parent will be queried for its value. Where possible, color values will be converted to their hex representation (for example, <code>#00ff00</code> instead of <code>rgb(0, 255, 0)</code>).</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="webElement-getAttribute">
+			<td>
+			<p><code>getAttribute(name: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to query for the value of the given attribute of the element.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="webElement-getText">
+			<td>
+			<p><code>getText(name: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Get the visible (not hidden by CSS) <code>innerText</code> of this element, including sub-elements, without any leading or trailing white space.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="webElement-getSize">
+			<td>
+			<p><code>getSize()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to compute the size of this element's bounding box, in pixels.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="webElement-getLocation">
+			<td>
+			<p><code>getLocation()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to compute the location of this element, in page space.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="webElement-isEnabled">
+			<td>
+			<p><code>isEnabled()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to query whether the DOM element represented by this instance is enabled, as dictated by the disabled attribute.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="webElement-isSelected">
+			<td>
+			<p><code>isSelected()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to query whether this element is selected.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="webElement-submit">
+			<td>
+			<p><code>submit()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to submit the form containing this element (or this element if it is a <code>FORM</code> element). This command is a no-op if the element is not contained in a form.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="webElement-clear">
+			<td>
+			<p><code>clear()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to clear the value of this element.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="webElement-isDisplayed">
+			<td>
+			<p><code>isDisplayed()</code></p>
+			</td>
+			<td>
+			<p>Schedules a command to test whether this element is currently displayed.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="actionsequence">ActionSequence: Link multiple actions</h2>
+
+<p>Action sequences can create complex user interactions with your website.</p>
+
+<ul>
+	<li>To create a new action sequence, use <a href="#browser-actions"><code>$browser.actions()</code></a>.</li>
+	<li>To link multiple actions together into a sequence, include <a href="#actionSequence-perform"><code>perform()</code></a> after each. This executes and then terminates individual sequences, including single-action sequences.</li>
+</ul>
+
+<p>The following table contains a list of available actions. For more information, see the <a href="https://github.com/browserstack/selenium-webdriver-nodejs/blob/master/docs/class_webdriver_ActionSequence.html">WebDriver ActionSequence documentation on GitHub</a>.</p>
+
+<table>
+	<thead>
+		<tr>
+			<th style="width: 400px;">Function</th>
+			<th>Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr id="actionSequence-click">
+			<td>
+			<p><code>click(opt_elementOrButton: <var>?</var>, opt_button: <var>?</var>)</code></p>
+			</td>
+			<td>
+			<p>Clicks a mouse button. If an element is provided, the mouse will first be moved to the center of that element. This is equivalent to <a href="#webElement-click"><code>WebElement.click()</code></a>.</p>
+
+			<p>Return value: actionsequence</p>
+			</td>
+		</tr>
+		<tr id="actionSequence-doubleClick">
+			<td>
+			<p><code>doubleClick(opt_elementOrButton: <var>?</var>, opt_button: <var>?</var>)</code></p>
+			</td>
+			<td>
+			<p>Double-clicks a mouse button. If an element is provided, the mouse will first be moved to the center of that element.</p>
+
+			<p>Return value: actionsequence</p>
+			</td>
+		</tr>
+		<tr id="actionSequence-dragAndDrop">
+			<td>
+			<p><code>dragAndDrop(element: <var>?</var>, location: <var>?</var>)</code></p>
+			</td>
+			<td>
+			<p>Convenience function for performing a drag and drop maneuver. The target element may be moved to the location of another element, or by an offset (in pixels). The location is an object with two properties <code>x</code> and <code>y</code>: <code>{x: <var>x_offset</var>, y: <var>y_offset</var>}</code>.</p>
+
+			<p>Return value: actionsequence</p>
+			</td>
+		</tr>
+		<tr id="actionSequence-keyDown">
+			<td>
+			<p><code>keyDown(key: <var>?</var>)</code></p>
+			</td>
+			<td>
+			<p>Performs a modifier key press. Must be one of <code>ALT</code>, <code>CONTROL</code>, <code>SHIFT</code>, <code>COMMAND</code>, or <code>META</code>. The modifier key is not released until <a href="#actionSequence-keyUp"><code>keyUp()</code></a> or <a href="#actionSequence-sendKeys"><code>sendKeys()</code></a> is called. The key press will be targeted at the currently focused element.</p>
+
+			<p>Return value: actionsequence</p>
+			</td>
+		</tr>
+		<tr id="actionSequence-keyUp">
+			<td>
+			<p><code>keyUp(key: <var>?</var>)</code></p>
+			</td>
+			<td>
+			<p>Performs a modifier key release. The release is targeted at the currently focused element.</p>
+
+			<p>Return value: actionsequence</p>
+			</td>
+		</tr>
+		<tr id="actionSequence-mouseDown">
+			<td>
+			<p><code>mouseDown(opt_elementOrButton: <var>?</var>, opt_button: <var>?</var>)</code></p>
+			</td>
+			<td>
+			<p>Presses a mouse button. The mouse button will not be released until <a href="#actionSequence-mouseUp"><code>mouseUp</code></a> is called, regardless of whether that call is made in this sequence or another. The behavior for out-of-order events (such as calling <code>mouseDown()</code> or <code><a href="#actionSequence-click">click()</a></code> when the button is already held down) is undefined.</p>
+
+			<p>Return value: actionsequence</p>
+			</td>
+		</tr>
+		<tr id="actionSequence-mouseUp">
+			<td>
+			<p><code>mouseUp(opt_elementOrButton: <var>?</var>, opt_button: <var>?</var>)</code></p>
+			</td>
+			<td>
+			<p>Releases a mouse button. Behavior is undefined for calling this function without a previous call to <a href="#actionSequence-mouseDown"><code>mouseDown()</code></a>.</p>
+
+			<p>Return value: actionsequence</p>
+			</td>
+		</tr>
+		<tr id="actionSequence-mouseMove">
+			<td>
+			<p><code>mouseMove(location: <var>?</var>, offset: <var>?</var>)</code></p>
+			</td>
+			<td>
+			<p>Moves the mouse. The location to move to may be specified in terms of the mouse's current location, an offset relative to the top-left corner of an element, or an element (in which case the middle of the element is used).</p>
+
+			<p>Return value: actionsequence</p>
+			</td>
+		</tr>
+		<tr id="actionSequence-perform">
+			<td>
+			<p><code>perform()</code></p>
+			</td>
+			<td>
+			<p>Executes this action sequence.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="actionSequence-sendKeys">
+			<td>
+			<p><code>sendKeys(args: <var>?</var>)</code></p>
+			</td>
+			<td>
+			<p>Simulates typing multiple keys. Each modifier key encountered in the sequence will not be released until it is encountered again. All key events will be targeted at the currently focused element. For a full list of supported non-alphanumeric keys, see the <a href="https://seleniumhq.github.io/selenium/docs/api/java/org/openqa/selenium/Keys.html">WebDriver enum key documentation on GitHub</a>.</p>
+
+			<p>Return value: actionsequence</p>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="promises">Promises: Link actions into sequences</h2>
+
+<p>You can also execute functions directly on promises. New Relic Synthetics is a native Node.js environment and uses standard Node.js promises.</p>
+
+<p>These functions evaluate the status of promises, cancel them, and more. In particular, you can create sequences of actions with the <a href="#promises-then"><code>then()</code></a> function and its siblings, <a href="#promises-thenFinally"><code>finally()</code></a> and <a href="#promises-thenCatch"><code>catch()</code></a>. For more information, see <a href="/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers#sequence">Sequence actions</a>.</p>
+
+<table>
+	<thead>
+		<tr>
+			<th style="width: 400px;">Function</th>
+			<th>Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr id="promises-isPending">
+			<td>
+			<p><code>isPending()</code></p>
+			</td>
+			<td>
+			<p>Whether this promise's value is still being computed.</p>
+
+			<p>Return value: boolean</p>
+			</td>
+		</tr>
+		<tr id="promises-then">
+			<td>
+			<p><code>then(opt_callback: <var>fn</var>(T: <var>?</var>), opt_errback: <var>fn</var>())</code></p>
+			</td>
+			<td>
+			<p>Registers listeners for when this instance is resolved. This is the basic function used to link synchronous actions in your script.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="promises-thenFinally">
+			<td>
+			<p><code>finally(callback: <var>fn</var>())</code></p>
+			</td>
+			<td>
+			<p>Registers a listener to invoke when this promise is resolved, regardless of whether the promise's value was successfully computed.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+		<tr id="promises-thenCatch">
+			<td>
+			<p><code>catch(callback: <var>fn</var>())</code></p>
+			</td>
+			<td>
+			<p>Registers a listener for when this promise is rejected.</p>
+
+			<p>Return value: promise</p>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="promises">Navigate: Move through browser history</h2>
+
+<p>The <code>$browser.navigate()</code> function exposes a number of functions that allow you to move backwards and forwards through your browser history, refresh your page and navigate to new pages.</p>
+
+<table>
+	<thead>
+		<tr>
+			<th style="width: 400px;">Function</th>
+			<th>Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr id="navigate-back">
+			<td>
+			<p><code>back()</code></p>
+			</td>
+			<td>
+			<p>Move back by one step in the browser's history.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="navigate-forward">
+			<td>
+			<p><code>forward()</code></p>
+			</td>
+			<td>
+			<p>Move forward by one step in the browser's history.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="navigate-refresh">
+			<td>
+			<p><code>refresh()</code></p>
+			</td>
+			<td>
+			<p>Refresh the current page.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+		<tr id="navigate-to">
+			<td>
+			<p><code>to(string: <var>url</var>)</code></p>
+			</td>
+			<td>
+			<p>Load a new webpage in the current browser window. <code>$browser.navigate().to()</code> is equivalent to <code><a href="/docs/synthetics/new-relic-synthetics/scripting-monitors/synthetics-scripted-browser-reference#browser-get">$browser.get()</a></code>.</p>
+
+			<p>Return value: void</p>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="until">Conditions: Pause and wait for conditions</h2>
+
+<p>Used with <code>$browser.wait</code>, <code>until</code> pauses your script execution until the condition is matched. For more information, see <a href="http://www.seleniumhq.org/docs/04_webdriver_advanced.jsp">Selenium's WebDriver <code>until</code> documentation</a>.</p>
+
+<p>The following are available functions for <code>$driver.until.<var>Condition</var></code>:</p>
+
+<table>
+	<thead>
+		<tr>
+			<th style="width: 400px;">Function</th>
+			<th>Description</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr id="conditions-ableToSwitchToFrame">
+			<td>
+			<p><code>ableToSwitchToFrame(frame: <var>?</var>)</code></p>
+			</td>
+			<td>
+			<p>Creates a condition that will wait until the input driver is able to switch to the designated frame. The target frame may be specified as:</p>
+
+			<ul>
+				<li>A numeric index into <code>window.frames</code> for the current frame</li>
+				<li>A <code>webdriver.WebElement</code>, which must reference a <code>FRAME</code> or <code>IFRAME</code> element on the current page</li>
+				<li>A locator which may be used to first locate a <code>FRAME</code> or <code>IFRAME</code> on the current page before attempting to switch to it</li>
+			</ul>
+
+			<p>Upon successful resolution of this condition, the driver will be left focused on the new frame.</p>
+
+			<p>Return value: condition</p>
+			</td>
+		</tr>
+		<tr id="conditions-alertIsPresent">
+			<td>
+			<p><code>alertIsPresent()</code></p>
+			</td>
+			<td>
+			<p>Creates a condition that waits for an alert to be opened. Upon success, the returned promise will be fulfilled with the handle for the opened alert.</p>
+
+			<p>Return value: condition</p>
+			</td>
+		</tr>
+		<tr id="conditions-elementIsDisabled">
+			<td>
+			<p><code>elementIsDisabled(element: $driver.<var>WebElement</var>)</code></p>
+			</td>
+			<td>
+			<p>Creates a condition that will wait for the given element to be disabled.</p>
+
+			<p>Return value: condition</p>
+			</td>
+		</tr>
+		<tr id="conditions-elementIsEnabled">
+			<td>
+			<p><code>elementIsEnabled(element: $driver.<var>WebElement</var>)</code></p>
+			</td>
+			<td>
+			<p>Creates a condition that will wait for the given element to be enabled.</p>
+
+			<p>Return value: condition</p>
+			</td>
+		</tr>
+		<tr id="conditions-elementIsNotVisible">
+			<td>
+			<p><code>elementIsNotVisible(element: $driver.<var>WebElement</var>)</code></p>
+			</td>
+			<td>
+			<p>Creates a condition that will wait for the given element to be in the DOM, yet not visible to the user.</p>
+
+			<p>Return value: condition</p>
+			</td>
+		</tr>
+		<tr id="conditions-elementIsVisible">
+			<td>
+			<p><code>elementIsVisible(element: $driver.<var>WebElement</var>)</code></p>
+			</td>
+			<td>
+			<p>Creates a condition that will wait for the given element to become visible.</p>
+
+			<p>Return value: condition</p>
+			</td>
+		</tr>
+		<tr id="conditions-elementIsSelected">
+			<td>
+			<p><code>elementIsSelected(element: $driver.<var>WebElement</var>)</code></p>
+			</td>
+			<td>
+			<p>Creates a condition that will wait for the given element to be selected.</p>
+
+			<p>Return value: condition</p>
+			</td>
+		</tr>
+		<tr id="conditions-elementLocated">
+			<td>
+			<p><code>elementLocated(element: $driver.<var>Locator</var>)</code></p>
+			</td>
+			<td>
+			<p>Creates a condition that will loop until an element is found with the given locator.</p>
+
+			<p>Return value: condition</p>
+			</td>
+		</tr>
+		<tr id="conditions-elementsLocated">
+			<td>
+			<p><code>elementsLocated(element: $driver.<var>Locator</var>)</code></p>
+			</td>
+			<td>
+			<p>Creates a condition that will loop until at least one element is found with the given locator.</p>
+
+			<p>Return value: condition</p>
+			n</td>
+		</tr>
+		<tr id="conditions-elementTextContains">
+			<td>
+			<p><code>elementTextContains(element: $driver.<var>WebElement</var>, substr: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Creates a condition that will wait for the given element's visible text to contain the given substring.</p>
+
+			<p>Return value: condition</p>
+			</td>
+		</tr>
+		<tr id="conditions-elementTextIs">
+			<td>
+			<p><code>elementTextIs(element: $driver.<var>WebElement</var>, text: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Case sensitive. Creates a condition that will wait for the given element's visible text to match the given text exactly.</p>
+
+			<p>Return value: condition</p>
+			n</td>
+		</tr>
+		<tr id="conditions-elementTextMatches">
+			<td>
+			<p><code>elementTextMatches(element: $driver.<var>WebElement</var>, regex: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Creates a condition that will wait for the given element's visible text to match a regular expression.</p>
+
+			<p>Return value: condition</p>
+			</td>
+		</tr>
+		<tr id="conditions-stalenessOf">
+			<td>
+			<p><code>stalenessOf(element: $driver.<var>WebElement</var>)</code></p>
+			</td>
+			<td>
+			<p>Creates a condition that will wait for the given element to become stale. An element is considered stale once it is removed from the DOM or a new page has loaded.</p>
+
+			<p>Return value: condition</p>
+			</td>
+		</tr>
+		<tr id="conditions-titleContains">
+			<td>
+			<p><code>titleContains(substr: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Creates a condition that will wait for the current page's title to contain the given substring.</p>
+
+			<p>Return value: condition</p>
+			</td>
+		</tr>
+		<tr id="conditions-titleIs">
+			<td>
+			<p><code>titleIs(title: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Creates a condition that will wait for the current page's title to match the given value.</p>
+
+			<p>Return value: condition</p>
+			</td>
+		</tr>
+		<tr id="conditions-titleMatches">
+			<td>
+			<p><code>titleMatches(regex: <var>string</var>)</code></p>
+			</td>
+			<td>
+			<p>Creates a condition that will wait for the current page's title to match the given regular expression.</p>
+
+			<p>Return value: condition</p>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<h2 id="more_help">For more help</h2>
+
+<p>Additional documentation resources include:</p>
+
+<ul>
+	<li><a href="/docs/synthetics/new-relic-synthetics/scripting-monitors/write-scripted-browsers">Write scripted browsers</a> (how to build WebDriverJS scripts for multi-step monitoring)</li>
+	<li><a href="/docs/synthetics/new-relic-synthetics/scripting-monitors/scripted-browser-examples">Scripted browser examples</a> (example code for scripted browsers, including comments, with examples such as searching a website and waiting for results to load)</li>
+	<li><a href="https://discuss.newrelic.com/tags/c/support-products-agents/synthetics/synthetics-script">Script repository in New Relic's Explorers Hub</a> (example scripts tagged <code>synthetics-script</code>, created and shared by our online technical community)</li>
+</ul>

--- a/src/templates/directory-index.js
+++ b/src/templates/directory-index.js
@@ -1,19 +1,10 @@
 import React from "react"
 import { Link, graphql } from "gatsby"
-
 import Layout from "../components/layout"
-import Image from "../components/image"
 import SEO from "../components/seo"
-import {strMethods} from "../helpers/helpers"
-
-function makeDisplayName(slug){
-  slug = slug.replace(/-/gim,' ');
-  slug = slug.split(/\//).map((e)=>{return strMethods.toTitleCase(e)}).join('/');
-  return slug;
-}
 
 export default (props) => {
-  const displayName = makeDisplayName(props.pageContext.slug);
+  const displayName = props.pageContext.slug;
   const children = props.pageContext.meta.children;
   // Compile listings - subdirectories and files
   let listings = [];
@@ -23,8 +14,8 @@ export default (props) => {
     isDir: true
   }}));
   listings = listings.concat(children.md.map(function(m){return {
-    path: m.fields.slug,
-    display: m.parent.name,
+    path: m.fields.urlPath,
+    display: m.frontmatter.title,
     isDir: false
   }}));
   return (

--- a/src/templates/directory-index.js
+++ b/src/templates/directory-index.js
@@ -1,0 +1,52 @@
+import React from "react"
+import { Link, graphql } from "gatsby"
+
+import Layout from "../components/layout"
+import Image from "../components/image"
+import SEO from "../components/seo"
+import {strMethods} from "../helpers/helpers"
+
+function makeDisplayName(slug){
+  slug = slug.replace(/-/gim,' ');
+  slug = slug.split(/\//).map((e)=>{return strMethods.toTitleCase(e)}).join('/');
+  return slug;
+}
+
+export default (props) => {
+  const displayName = makeDisplayName(props.pageContext.slug);
+  const children = props.pageContext.meta.children;
+  // Compile listings - subdirectories and files
+  let listings = [];
+  listings = listings.concat(children.dirs.map(function(d){return {
+    path: '/' + d.relativePath,
+    display: '/' + d.name,
+    isDir: true
+  }}));
+  listings = listings.concat(children.md.map(function(m){return {
+    path: m.fields.slug,
+    display: m.parent.name,
+    isDir: false
+  }}));
+  return (
+    <Layout>
+      <SEO title={`${props.pageContext.slug}`} />
+      <h1>Generated Index Page - {`${displayName}`}</h1>
+      <div className="directoryListingWrapper">
+        <div className="directoryListingRow">
+          <i className="material-icons">folder</i>
+          <Link to={`${document.location.pathname + '/../'}`}>..</Link>
+        </div>
+        {listings.map((listing)=>{
+          return (
+            <div className="directoryListingRow" key={`${listing.path + ((new Date()).getTime())}`}>
+              <i className="material-icons">{listing.isDir ? 'folder' : 'description'}</i>
+              <Link to={`${listing.path}`}>
+                {listing.display}
+              </Link>
+            </div>
+          )
+        })}
+      </div>
+    </Layout>
+  )
+}


### PR DESCRIPTION
Iterates through all subdirectories via graphql and if directory does not have an index.md file it automatically creates a page that uses the directory-index.js template.

Directory cannot be totally empty. Must eventually contain a .md file at the leaf.

Things out of scope but that should be done:
* add template that displays content from an authored index.md
* make it look prettier at some point

For JSON output. Uses my forked version of the plugin. Cloned repo down, made changes, and ran the build, manually replaced /lib folder in the node_modules/gatsby-plugin-json-output folder. Could try updating package.json to use my forked version and run install on it. Waiting to hear back about my PR into source repo though