### PR TITLE
Add json feed directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Your site is now running at `http://localhost:8000`!
 * Add automatic directory index pages for each directory
   * Change index.md template to use its own template
 * Add redirects
+* Add JSON feed for directories (proof of concept for feeding top level folder names to search app)
 * Use frontmatter to set `<meta>` and other related tags (swiftype, SEO, hreflang links)
 * Add field validation for certain graphql/frontmatter types
   * `path`: ensure unique. decide if user should supply or automatically generated based on directory? use default gatsby pattern (slugified directory and filename path) if not specified

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -118,6 +118,32 @@ module.exports = {
       }
     },
     {
+      resolve: `gatsby-plugin-json-output`,
+      options: {
+        siteUrl: 'http://localhost.com:8000',
+        graphQLQuery: `
+        {
+          allDirectory(filter: {relativeDirectory: {eq: "docs"}}) {
+            edges {
+              node {
+                name
+                id
+                relativePath
+              }
+            }
+          }
+        }
+      `,
+      serializeFeed: results => results.data.allDirectory.edges.map(({ node }) => ({
+        id: node.id,
+        name: node.name,
+        path: node.relativePath
+      })),
+      nodesPerFeedFile: 100,
+      feedName: 'docs-folders'
+      }
+    },
+    {
       resolve: 'gatsby-plugin-netlify-cms',
     },
   ],

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -71,13 +71,14 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
   }
 
   result.data.allMarkdownRemark.edges.forEach(({ node }) => {
+    console.log(node.fields.urlPath)
     const relativePath = node.parent.relativePath.split('.')
     // Get dir of file
     const subdirAbs = path.dirname(node.fileAbsolutePath);
     // Note that this md file is child of dir
     recordAsChild(subdirAbs,node,false);
     createPage({
-      path: node.frontmatter.path || `/${relativePath[0]}`,
+      path: node.fields.urlPath,
       component: path.resolve(
         `src/templates/${node.frontmatter.templateKey}.js`
       ),


### PR DESCRIPTION
Still predicated on ability to name feed files.

As mentioned in last commit, this is viable to replace taxonomies.json endpoint that current search nerdlet uses to populate main topic area dropdown. It would require templates to use these names and for swiftype to crawl and reindex those names before going live.