### PR TITLE
Add xml sitemap plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,19 @@ npm start
 Your site is now running at `http://localhost:8000`!
 
 # TODO
-* Change index.mdx template to use its own template
-  * Eventually figure out how to add dynamic content to page like links to related docs, etc)
-* Add redirects
+
+## Must Do's
+Things we need to support out of the box for MVP:
+* Add XML sitemap
 * Use frontmatter to set `<meta>` and other related tags (swiftype, SEO, hreflang links)
+* Change index.mdx template to use its own template
+
+## Do later
+Things we can do later as future enhancement / not in scope for MVP:
+* Add / figure out how translation (smartling)
 * Add field validation for certain graphql/frontmatter types
   * `path`: ensure unique. decide if user should supply or automatically generated based on directory? use default gatsby pattern (slugified directory and filename path) if not specified
-* Add / figure out how translation (smartling)
+* Eventually figure out how to add dynamic content to directory index pages like links to related docs, etc)
 
 # Notes to self (or whomever is reading)
 * I'm inclined to not make API doc its own content type, because many fields are HTML fields and it won't really work with frontmatter syntax.

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,12 +1,14 @@
 module.exports = {
   siteMetadata: {
     title: `New Relic Developers`,
+    siteUrl: `https://mystifying-mahavira-ba6a10.netlify.app`,
     description: `Do more on our platform and make New Relic your own with APIs, SDKs, code snippets, tutorials, and more developer tools.`,
     author: `New Relic`,
   },
   plugins: [
     `gatsby-plugin-react-helmet`,
     `gatsby-plugin-netlify`,
+    `gatsby-plugin-sitemap`,
     `gatsby-plugin-mdx`,
     {
       resolve: `gatsby-source-filesystem`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10684,6 +10684,27 @@
         }
       }
     },
+    "gatsby-plugin-sitemap": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-2.4.5.tgz",
+      "integrity": "sha512-jcWXFDzi3PtJ8Fh1ygWxei0yMCagjjZPJMuFYut4IC6RUesQJUu2LIloAZLhOiKse/Ej4Lvm92/dPKVKSClzFQ==",
+      "requires": {
+        "@babel/runtime": "^7.10.2",
+        "minimatch": "^3.0.4",
+        "pify": "^3.0.0",
+        "sitemap": "^1.13.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "gatsby-react-router-scroll": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.2.2.tgz",
@@ -19465,6 +19486,15 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
+    "sitemap": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-1.13.0.tgz",
+      "integrity": "sha1-Vpy+IYAgKSamKiZs094Jyc60P4M=",
+      "requires": {
+        "underscore": "^1.7.0",
+        "url-join": "^1.1.0"
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -21073,6 +21103,11 @@
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
     },
+    "underscore": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
+      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
+    },
     "underscore.string": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
@@ -21622,6 +21657,11 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
+    },
+    "url-join": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+      "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
     },
     "url-loader": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gatsby-plugin-react-helmet": "^3.2.4",
     "gatsby-plugin-sass": "^2.2.3",
     "gatsby-plugin-sharp": "^2.5.6",
+    "gatsby-plugin-sitemap": "^2.4.5",
     "gatsby-source-filesystem": "^2.2.4",
     "gatsby-transformer-remark": "^2.7.3",
     "gatsby-transformer-sharp": "^2.4.6",


### PR DESCRIPTION
Leaving it add all pages to sitemap for now. May want to add some custom config down the road if some content should not be indexed by robots. Since content is publicly available in github, it should be considered public. May not need to exclude some content (maybe attribute definitions).

Config options are at https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap